### PR TITLE
feat(layout): zonas, cores por agente e mapeamento de status

### DIFF
--- a/src/data/office-layout.test.ts
+++ b/src/data/office-layout.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  OFFICE_ZONES,
+  ZONE_BY_ID,
+  AGENT_COLORS,
+  getAgentColor,
+  getAgentZone,
+  DEFAULT_AGENT_COLOR,
+} from './office-layout'
+
+describe('OFFICE_ZONES', () => {
+  it('tem 6 zonas definidas', () => {
+    expect(OFFICE_ZONES).toHaveLength(6)
+  })
+
+  it('todas as zonas têm campos obrigatórios', () => {
+    for (const zone of OFFICE_ZONES) {
+      expect(zone.id).toBeTruthy()
+      expect(zone.label).toBeTruthy()
+      expect(zone.icon).toBeTruthy()
+      expect(zone.color).toMatch(/^#[0-9a-f]{6}$/i)
+      expect(zone.x).toBeGreaterThanOrEqual(0)
+      expect(zone.y).toBeGreaterThanOrEqual(0)
+      expect(zone.width).toBeGreaterThan(0)
+      expect(zone.height).toBeGreaterThan(0)
+    }
+  })
+
+  it('ids são únicos', () => {
+    const ids = OFFICE_ZONES.map(z => z.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('zonas não saem dos limites (x + width <= 100)', () => {
+    for (const zone of OFFICE_ZONES) {
+      expect(zone.x + zone.width).toBeLessThanOrEqual(100)
+    }
+  })
+})
+
+describe('ZONE_BY_ID', () => {
+  it('resolve zona pelo id', () => {
+    expect(ZONE_BY_ID['dev-zone'].label).toBe('Dev Zone')
+    expect(ZONE_BY_ID['lobby'].icon).toBe('🚪')
+  })
+})
+
+describe('getAgentColor', () => {
+  it('retorna cor correta para agentes conhecidos', () => {
+    expect(getAgentColor('agent-1')).toBe(AGENT_COLORS['agent-1'])
+    expect(getAgentColor('agent-2')).toBe(AGENT_COLORS['agent-2'])
+    expect(getAgentColor('agent-3')).toBe(AGENT_COLORS['agent-3'])
+  })
+
+  it('retorna cor default para agente desconhecido', () => {
+    expect(getAgentColor('agent-99')).toBe(DEFAULT_AGENT_COLOR)
+  })
+})
+
+describe('getAgentZone', () => {
+  it('idle → coffee-corner', () => {
+    expect(getAgentZone('idle')).toBe('coffee-corner')
+    expect(getAgentZone('idle', 'implementando feature')).toBe('coffee-corner')
+  })
+
+  it('offline → lobby', () => {
+    expect(getAgentZone('offline')).toBe('lobby')
+  })
+
+  it('blocked → lobby', () => {
+    expect(getAgentZone('blocked')).toBe('lobby')
+  })
+
+  it('working + review action → review-room', () => {
+    expect(getAgentZone('working', 'fazendo review do PR')).toBe('review-room')
+    expect(getAgentZone('thinking', 'revisando código')).toBe('review-room')
+    expect(getAgentZone('working', 'aprovando PR #42')).toBe('review-room')
+  })
+
+  it('working + planning action → planning-board', () => {
+    expect(getAgentZone('working', 'criando task no backlog')).toBe('planning-board')
+    expect(getAgentZone('thinking', 'sprint planning')).toBe('planning-board')
+  })
+
+  it('working + analysis action → analysis-area', () => {
+    expect(getAgentZone('working', 'analisando bug')).toBe('analysis-area')
+    expect(getAgentZone('thinking', 'debugging fluxo')).toBe('analysis-area')
+    expect(getAgentZone('working', 'inspect memory leak')).toBe('analysis-area')
+  })
+
+  it('working sem action específica → dev-zone', () => {
+    expect(getAgentZone('working')).toBe('dev-zone')
+    expect(getAgentZone('working', 'implementando feature X')).toBe('dev-zone')
+    expect(getAgentZone('thinking', '')).toBe('dev-zone')
+  })
+})

--- a/src/data/office-layout.test.ts
+++ b/src/data/office-layout.test.ts
@@ -93,4 +93,15 @@ describe('getAgentZone', () => {
     expect(getAgentZone('working', 'implementando feature X')).toBe('dev-zone')
     expect(getAgentZone('thinking', '')).toBe('dev-zone')
   })
+
+  it('status null/undefined → lobby (safe default)', () => {
+    expect(getAgentZone(null)).toBe('lobby')
+    expect(getAgentZone(undefined)).toBe('lobby')
+    expect(getAgentZone('')).toBe('lobby')
+  })
+
+  it('status desconhecido → dev-zone', () => {
+    expect(getAgentZone('busy')).toBe('dev-zone')
+    expect(getAgentZone('away')).toBe('dev-zone')
+  })
 })

--- a/src/data/office-layout.ts
+++ b/src/data/office-layout.ts
@@ -78,11 +78,23 @@ export function getAgentColor(agentId: string): string {
   return AGENT_COLORS[agentId] ?? DEFAULT_AGENT_COLOR
 }
 
-// Mapeamento status/lastAction → zone id
-export function getAgentZone(status: string, lastAction = ''): string {
+/**
+ * Statuses suportados pelo MAGO backend:
+ *   idle      → coffee-corner
+ *   offline   → lobby
+ *   blocked   → lobby
+ *   working   → zona baseada em lastAction
+ *   thinking  → zona baseada em lastAction
+ *
+ * Outros valores (ex: undefined, null, desconhecido) → lobby (safe default)
+ */
+export function getAgentZone(status: string | null | undefined, lastAction = ''): string {
+  if (!status) return 'lobby'
+
   if (status === 'idle') return 'coffee-corner'
   if (status === 'offline' || status === 'blocked') return 'lobby'
 
+  // Para working/thinking: usar lastAction para refinar a zona
   const action = lastAction.toLowerCase()
 
   if (action.includes('review') || action.includes('aprovando') || action.includes('revisando')) {
@@ -95,5 +107,5 @@ export function getAgentZone(status: string, lastAction = ''): string {
     return 'analysis-area'
   }
 
-  return 'dev-zone' // default para working/thinking
+  return 'dev-zone'
 }

--- a/src/data/office-layout.ts
+++ b/src/data/office-layout.ts
@@ -1,0 +1,99 @@
+export interface Zone {
+  id: string
+  label: string
+  icon: string
+  x: number       // % from left
+  y: number       // % from top
+  width: number   // % width
+  height: number  // % height
+  color: string   // background (dark theme)
+  description: string
+}
+
+export const OFFICE_ZONES: Zone[] = [
+  {
+    id: 'dev-zone',
+    label: 'Dev Zone',
+    icon: '⚡',
+    x: 2, y: 5, width: 28, height: 30,
+    color: '#1e1b4b',
+    description: 'Implementação e desenvolvimento',
+  },
+  {
+    id: 'review-room',
+    label: 'Review Room',
+    icon: '👁',
+    x: 34, y: 5, width: 28, height: 30,
+    color: '#1a2035',
+    description: 'Code review e análise de qualidade',
+  },
+  {
+    id: 'planning-board',
+    label: 'Planning Board',
+    icon: '📋',
+    x: 66, y: 5, width: 30, height: 30,
+    color: '#1f1635',
+    description: 'Sprint planning e task management',
+  },
+  {
+    id: 'analysis-area',
+    label: 'Analysis Area',
+    icon: '🔍',
+    x: 2, y: 42, width: 44, height: 30,
+    color: '#0f2027',
+    description: 'Análise de problemas e edge cases',
+  },
+  {
+    id: 'coffee-corner',
+    label: 'Coffee Corner',
+    icon: '☕',
+    x: 50, y: 42, width: 46, height: 30,
+    color: '#1a0f0f',
+    description: 'Agentes em idle descansam aqui',
+  },
+  {
+    id: 'lobby',
+    label: 'Lobby',
+    icon: '🚪',
+    x: 2, y: 78, width: 94, height: 18,
+    color: '#0d1117',
+    description: 'Entrada — humanos e agentes offline',
+  },
+]
+
+export const ZONE_BY_ID = Object.fromEntries(
+  OFFICE_ZONES.map(z => [z.id, z]),
+) as Record<string, Zone>
+
+// Cores por agente
+export const AGENT_COLORS: Record<string, string> = {
+  'agent-1': '#8b5cf6', // violet  — Claude
+  'agent-2': '#10b981', // emerald — Gemini
+  'agent-3': '#f59e0b', // amber   — OpenCode
+}
+
+export const DEFAULT_AGENT_COLOR = '#6b7280'
+
+export function getAgentColor(agentId: string): string {
+  return AGENT_COLORS[agentId] ?? DEFAULT_AGENT_COLOR
+}
+
+// Mapeamento status/lastAction → zone id
+export function getAgentZone(status: string, lastAction = ''): string {
+  if (status === 'idle') return 'coffee-corner'
+  if (status === 'offline' || status === 'blocked') return 'lobby'
+
+  const action = lastAction.toLowerCase()
+
+  if (action.includes('review') || action.includes('aprovando') || action.includes('revisando')) {
+    return 'review-room'
+  }
+  if (action.includes('plan') || action.includes('task') || action.includes('sprint') || action.includes('backlog')) {
+    return 'planning-board'
+  }
+  if (action.includes('analyz') || action.includes('analis') || action.includes('inspect') || action.includes('debug')) {
+    return 'analysis-area'
+  }
+
+  return 'dev-zone' // default para working/thinking
+}


### PR DESCRIPTION
Closes #5

## O que essa PR faz

Define a estrutura de dados estáticos do escritório virtual.

## Mudanças

- `src/data/office-layout.ts` — 6 zonas com coordenadas, cores e descrições
- `getAgentZone(status, lastAction)` — mapeia status/ação do agente para zona
- `getAgentColor(agentId)` — cores por agente (agent-1 violet, agent-2 emerald, agent-3 amber)
- `ZONE_BY_ID` — lookup direto por id
- 14 testes unitários