### PR TITLE
feat(canvas): officecanvas, officeroom e officehud

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,57 +1,8 @@
 import { useSocket } from './hooks/useSocket'
-import type { ConnectionStatus } from './hooks/useSocket'
-
-const STATUS_COLOR: Record<ConnectionStatus, string> = {
-  connecting: '#f59e0b',
-  connected: '#00ff41',
-  reconnecting: '#f59e0b',
-  disconnected: '#6b7280',
-  error: '#ef4444',
-}
-
-const STATUS_LABEL: Record<ConnectionStatus, string> = {
-  connecting: 'conectando...',
-  connected: 'conectado',
-  reconnecting: 'reconectando...',
-  disconnected: 'desconectado',
-  error: 'erro de conexão',
-}
+import { OfficeCanvas } from './components/OfficeCanvas'
 
 export function App() {
   const { status } = useSocket()
-  const color = STATUS_COLOR[status]
 
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100vh',
-        flexDirection: 'column',
-        gap: 12,
-        background: '#0d1117',
-        color: '#00ff41',
-        fontFamily: 'JetBrains Mono, monospace',
-      }}
-    >
-      <span style={{ fontSize: 32 }}>⌂</span>
-      <span style={{ fontSize: 14, fontWeight: 700, letterSpacing: '0.1em' }}>MAGO OFFICE</span>
-      <span style={{ fontSize: 11, opacity: 0.5 }}>v0.1 — foundation</span>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 8 }}>
-        <span
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: '50%',
-            background: color,
-            boxShadow: `0 0 6px ${color}`,
-          }}
-        />
-        <span style={{ fontSize: 11, color, opacity: 0.9 }}>
-          backend {STATUS_LABEL[status]}
-        </span>
-      </div>
-    </div>
-  )
+  return <OfficeCanvas connectionStatus={status} />
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,5 +4,23 @@ import { OfficeCanvas } from './components/OfficeCanvas'
 export function App() {
   const { status } = useSocket()
 
-  return <OfficeCanvas connectionStatus={status} />
+  return (
+    <>
+      <OfficeCanvas connectionStatus={status} />
+      <div
+        style={{
+          position: 'fixed',
+          top: 16,
+          left: 16,
+          fontFamily: 'JetBrains Mono, monospace',
+          fontSize: 10,
+          color: '#374151',
+          pointerEvents: 'none',
+          userSelect: 'none',
+        }}
+      >
+        v0.2 — office map
+      </div>
+    </>
+  )
 }

--- a/src/components/OfficeCanvas.test.tsx
+++ b/src/components/OfficeCanvas.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OfficeCanvas } from './OfficeCanvas'
+import { OFFICE_ZONES } from '../data/office-layout'
+
+describe('OfficeCanvas', () => {
+  it('renderiza todas as zonas', () => {
+    render(<OfficeCanvas connectionStatus="connected" />)
+    for (const zone of OFFICE_ZONES) {
+      expect(document.querySelector(`[data-zone-id="${zone.id}"]`)).toBeTruthy()
+    }
+  })
+
+  it('renderiza o HUD com status connected', () => {
+    render(<OfficeCanvas connectionStatus="connected" />)
+    expect(screen.getByText('online')).toBeTruthy()
+  })
+
+  it('renderiza o HUD com status error', () => {
+    render(<OfficeCanvas connectionStatus="error" />)
+    expect(screen.getByText('erro')).toBeTruthy()
+  })
+
+  it('exibe contagem de agentes', () => {
+    render(<OfficeCanvas connectionStatus="connected" agentCount={3} />)
+    expect(screen.getByText('3 agents')).toBeTruthy()
+  })
+
+  it('exibe "agent" no singular', () => {
+    render(<OfficeCanvas connectionStatus="connected" agentCount={1} />)
+    expect(screen.getByText('1 agent')).toBeTruthy()
+  })
+
+  it('não exibe humans quando humanCount é 0', () => {
+    render(<OfficeCanvas connectionStatus="connected" humanCount={0} />)
+    expect(screen.queryByText(/human/)).toBeNull()
+  })
+
+  it('exibe humans quando humanCount > 0', () => {
+    render(<OfficeCanvas connectionStatus="connected" humanCount={2} />)
+    expect(screen.getByText('2 humans')).toBeTruthy()
+  })
+
+  it('renderiza children dentro do canvas', () => {
+    render(
+      <OfficeCanvas connectionStatus="connected">
+        <div data-testid="avatar">Agent Avatar</div>
+      </OfficeCanvas>,
+    )
+    expect(screen.getByTestId('avatar')).toBeTruthy()
+  })
+})

--- a/src/components/OfficeCanvas.tsx
+++ b/src/components/OfficeCanvas.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react'
+import { OFFICE_ZONES } from '../data/office-layout'
+import { OfficeRoom } from './OfficeRoom'
+import { OfficeHUD } from './OfficeHUD'
+import type { ConnectionStatus } from '../hooks/useSocket'
+
+interface OfficeCanvasProps {
+  children?: ReactNode
+  connectionStatus: ConnectionStatus
+  agentCount?: number
+  humanCount?: number
+}
+
+const GRID_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  backgroundImage: `
+    radial-gradient(circle, #1f2937 1px, transparent 1px)
+  `,
+  backgroundSize: '28px 28px',
+  opacity: 0.4,
+  pointerEvents: 'none',
+}
+
+export function OfficeCanvas({
+  children,
+  connectionStatus,
+  agentCount = 0,
+  humanCount = 0,
+}: OfficeCanvasProps) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100vh',
+        background: '#0d1117',
+        overflow: 'hidden',
+        fontFamily: 'JetBrains Mono, monospace',
+      }}
+    >
+      {/* Grid decorativo de fundo */}
+      <div style={GRID_STYLE} />
+
+      {/* Zonas do escritório */}
+      {OFFICE_ZONES.map(zone => (
+        <OfficeRoom key={zone.id} zone={zone} />
+      ))}
+
+      {/* Avatares (agents + humans) — passados como children */}
+      {children}
+
+      {/* HUD: status de conexão + contagem */}
+      <OfficeHUD
+        connectionStatus={connectionStatus}
+        agentCount={agentCount}
+        humanCount={humanCount}
+      />
+    </div>
+  )
+}

--- a/src/components/OfficeHUD.tsx
+++ b/src/components/OfficeHUD.tsx
@@ -1,0 +1,75 @@
+import type { ConnectionStatus } from '../hooks/useSocket'
+
+interface OfficeHUDProps {
+  connectionStatus: ConnectionStatus
+  agentCount: number
+  humanCount: number
+}
+
+const STATUS_COLOR: Record<ConnectionStatus, string> = {
+  connecting: '#f59e0b',
+  connected: '#00ff41',
+  reconnecting: '#f59e0b',
+  disconnected: '#6b7280',
+  error: '#ef4444',
+}
+
+const STATUS_LABEL: Record<ConnectionStatus, string> = {
+  connecting: 'conectando',
+  connected: 'online',
+  reconnecting: 'reconectando',
+  disconnected: 'offline',
+  error: 'erro',
+}
+
+export function OfficeHUD({ connectionStatus, agentCount, humanCount }: OfficeHUDProps) {
+  const color = STATUS_COLOR[connectionStatus]
+  const label = STATUS_LABEL[connectionStatus]
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 16,
+        right: 16,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '6px 12px',
+        background: '#0d1117cc',
+        border: '1px solid #1f2937',
+        borderRadius: 6,
+        backdropFilter: 'blur(8px)',
+        fontFamily: 'JetBrains Mono, monospace',
+        fontSize: 11,
+        color: '#6b7280',
+      }}
+    >
+      {/* Status conexão */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+        <span
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: color,
+            boxShadow: `0 0 4px ${color}`,
+          }}
+        />
+        <span style={{ color }}>{label}</span>
+      </div>
+
+      <span style={{ color: '#374151' }}>│</span>
+
+      {/* Agentes online */}
+      <span>{agentCount} agent{agentCount !== 1 ? 's' : ''}</span>
+
+      {humanCount > 0 && (
+        <>
+          <span style={{ color: '#374151' }}>│</span>
+          <span>{humanCount} human{humanCount !== 1 ? 's' : ''}</span>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/OfficeHUD.tsx
+++ b/src/components/OfficeHUD.tsx
@@ -1,28 +1,18 @@
+import { memo } from 'react'
 import type { ConnectionStatus } from '../hooks/useSocket'
+import { STATUS_COLOR, STATUS_LABEL } from '../constants/status'
 
 interface OfficeHUDProps {
   connectionStatus: ConnectionStatus
-  agentCount: number
-  humanCount: number
+  agentCount?: number
+  humanCount?: number
 }
 
-const STATUS_COLOR: Record<ConnectionStatus, string> = {
-  connecting: '#f59e0b',
-  connected: '#00ff41',
-  reconnecting: '#f59e0b',
-  disconnected: '#6b7280',
-  error: '#ef4444',
-}
-
-const STATUS_LABEL: Record<ConnectionStatus, string> = {
-  connecting: 'conectando',
-  connected: 'online',
-  reconnecting: 'reconectando',
-  disconnected: 'offline',
-  error: 'erro',
-}
-
-export function OfficeHUD({ connectionStatus, agentCount, humanCount }: OfficeHUDProps) {
+export const OfficeHUD = memo(function OfficeHUD({
+  connectionStatus,
+  agentCount = 0,
+  humanCount = 0,
+}: OfficeHUDProps) {
   const color = STATUS_COLOR[connectionStatus]
   const label = STATUS_LABEL[connectionStatus]
 
@@ -48,6 +38,8 @@ export function OfficeHUD({ connectionStatus, agentCount, humanCount }: OfficeHU
       {/* Status conexão */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
         <span
+          aria-label={`status: ${label}`}
+          role="status"
           style={{
             width: 6,
             height: 6,
@@ -72,4 +64,4 @@ export function OfficeHUD({ connectionStatus, agentCount, humanCount }: OfficeHU
       )}
     </div>
   )
-}
+})

--- a/src/components/OfficeRoom.test.tsx
+++ b/src/components/OfficeRoom.test.tsx
@@ -12,7 +12,7 @@ const mockZone: Zone = {
   width: 30,
   height: 25,
   color: '#1a1a2e',
-  agentIds: [],
+  description: 'Zona de teste',
 }
 
 describe('OfficeRoom', () => {

--- a/src/components/OfficeRoom.test.tsx
+++ b/src/components/OfficeRoom.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OfficeRoom } from './OfficeRoom'
+import type { Zone } from '../data/office-layout'
+
+const mockZone: Zone = {
+  id: 'test-zone',
+  label: 'Test Zone',
+  icon: '🧪',
+  x: 10,
+  y: 20,
+  width: 30,
+  height: 25,
+  color: '#1a1a2e',
+  agentIds: [],
+}
+
+describe('OfficeRoom', () => {
+  it('renderiza com data-zone-id correto', () => {
+    render(<OfficeRoom zone={mockZone} />)
+    expect(document.querySelector('[data-zone-id="test-zone"]')).toBeTruthy()
+  })
+
+  it('exibe o ícone da zona', () => {
+    render(<OfficeRoom zone={mockZone} />)
+    expect(screen.getByText('🧪')).toBeTruthy()
+  })
+
+  it('exibe o label da zona', () => {
+    render(<OfficeRoom zone={mockZone} />)
+    expect(screen.getByText('Test Zone')).toBeTruthy()
+  })
+
+  it('posiciona a zona com as coordenadas corretas', () => {
+    render(<OfficeRoom zone={mockZone} />)
+    const el = document.querySelector('[data-zone-id="test-zone"]') as HTMLElement
+    expect(el.style.left).toBe('10%')
+    expect(el.style.top).toBe('20%')
+    expect(el.style.width).toBe('30%')
+    expect(el.style.height).toBe('25%')
+  })
+
+  it('aplica a cor de fundo da zona', () => {
+    render(<OfficeRoom zone={mockZone} />)
+    const el = document.querySelector('[data-zone-id="test-zone"]') as HTMLElement
+    expect(el.style.background).toBe('rgb(26, 26, 46)')
+  })
+})

--- a/src/components/OfficeRoom.tsx
+++ b/src/components/OfficeRoom.tsx
@@ -1,10 +1,11 @@
+import { memo } from 'react'
 import type { Zone } from '../data/office-layout'
 
 interface OfficeRoomProps {
   zone: Zone
 }
 
-export function OfficeRoom({ zone }: OfficeRoomProps) {
+export const OfficeRoom = memo(function OfficeRoom({ zone }: OfficeRoomProps) {
   return (
     <div
       data-zone-id={zone.id}
@@ -45,4 +46,4 @@ export function OfficeRoom({ zone }: OfficeRoomProps) {
       </div>
     </div>
   )
-}
+})

--- a/src/components/OfficeRoom.tsx
+++ b/src/components/OfficeRoom.tsx
@@ -1,0 +1,48 @@
+import type { Zone } from '../data/office-layout'
+
+interface OfficeRoomProps {
+  zone: Zone
+}
+
+export function OfficeRoom({ zone }: OfficeRoomProps) {
+  return (
+    <div
+      data-zone-id={zone.id}
+      style={{
+        position: 'absolute',
+        left: `${zone.x}%`,
+        top: `${zone.y}%`,
+        width: `${zone.width}%`,
+        height: `${zone.height}%`,
+        background: zone.color,
+        border: '1px solid #1f2937',
+        borderRadius: 8,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header da zona */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '6px 10px',
+          borderBottom: '1px solid #1f293780',
+        }}
+      >
+        <span style={{ fontSize: 12 }}>{zone.icon}</span>
+        <span
+          style={{
+            fontSize: 10,
+            fontFamily: 'JetBrains Mono, monospace',
+            color: '#6b7280',
+            letterSpacing: '0.05em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {zone.label}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -1,0 +1,17 @@
+import type { ConnectionStatus } from '../hooks/useSocket'
+
+export const STATUS_COLOR: Record<ConnectionStatus, string> = {
+  connecting: '#f59e0b',
+  connected: '#00ff41',
+  reconnecting: '#f59e0b',
+  disconnected: '#6b7280',
+  error: '#ef4444',
+}
+
+export const STATUS_LABEL: Record<ConnectionStatus, string> = {
+  connecting: 'conectando',
+  connected: 'online',
+  reconnecting: 'reconectando',
+  disconnected: 'offline',
+  error: 'erro',
+}


### PR DESCRIPTION
Closes #6

## Mudanças

- `OfficeCanvas` — container full-screen com grid decorativo de pontos, renderiza zonas e passa children para avatares
- `OfficeRoom` — zona posicionada com coordenadas percentuais, header com ícone e label
- `OfficeHUD` — HUD com status de conexão (dot colorido) + contagem de agentes/humans
- `App.tsx` simplificado: apenas conecta socket e passa status para o canvas
- 8 testes de componente cobrindo renderização, HUD e children