### PR TITLE
feat(layout): getagentposition com anti-sobreposicao de avatares

### DIFF
--- a/src/data/office-layout.test.ts
+++ b/src/data/office-layout.test.ts
@@ -5,6 +5,7 @@ import {
   AGENT_COLORS,
   getAgentColor,
   getAgentZone,
+  getAgentPosition,
   DEFAULT_AGENT_COLOR,
 } from './office-layout'
 
@@ -103,5 +104,53 @@ describe('getAgentZone', () => {
   it('status desconhecido → dev-zone', () => {
     expect(getAgentZone('busy')).toBe('dev-zone')
     expect(getAgentZone('away')).toBe('dev-zone')
+  })
+})
+
+describe('getAgentPosition', () => {
+  it('calcula posição dentro da zona para agente-1 (index 0)', () => {
+    // dev-zone: x=2, y=5, width=28, height=30
+    // offset[0] = { x:25, y:40 } → x = 2 + 28*0.25 = 9, y = 5 + 30*0.40 = 17
+    const pos = getAgentPosition('dev-zone', 0)
+    expect(pos.x).toBe(9)
+    expect(pos.y).toBe(17)
+  })
+
+  it('calcula posição dentro da zona para agente-2 (index 1)', () => {
+    // dev-zone: x=2, y=5, width=28, height=30
+    // offset[1] = { x:50, y:40 } → x = 2 + 28*0.50 = 16, y = 5 + 30*0.40 = 17
+    const pos = getAgentPosition('dev-zone', 1)
+    expect(pos.x).toBe(16)
+    expect(pos.y).toBe(17)
+  })
+
+  it('calcula posição dentro da zona para agente-3 (index 2)', () => {
+    // dev-zone: x=2, y=5, width=28, height=30
+    // offset[2] = { x:75, y:40 } → x = 2 + 28*0.75 = 23, y = 5 + 30*0.40 = 17
+    const pos = getAgentPosition('dev-zone', 2)
+    expect(pos.x).toBe(23)
+    expect(pos.y).toBe(17)
+  })
+
+  it('retorna posição central para zona desconhecida', () => {
+    const pos = getAgentPosition('zona-inexistente', 0)
+    expect(pos).toEqual({ x: 50, y: 50 })
+  })
+
+  it('usa offset default para índice fora do range', () => {
+    // index 99 não existe → offset default { x:50, y:50 }
+    // dev-zone: x=2, y=5, width=28, height=30 → x=2+14=16, y=5+15=20
+    const pos = getAgentPosition('dev-zone', 99)
+    expect(pos.x).toBe(16)
+    expect(pos.y).toBe(20)
+  })
+
+  it('cada agente tem posição horizontal distinta na mesma zona', () => {
+    const p0 = getAgentPosition('coffee-corner', 0)
+    const p1 = getAgentPosition('coffee-corner', 1)
+    const p2 = getAgentPosition('coffee-corner', 2)
+    expect(p0.x).not.toBe(p1.x)
+    expect(p1.x).not.toBe(p2.x)
+    expect(p0.x).not.toBe(p2.x)
   })
 })

--- a/src/data/office-layout.ts
+++ b/src/data/office-layout.ts
@@ -65,6 +65,45 @@ export const ZONE_BY_ID = Object.fromEntries(
   OFFICE_ZONES.map(z => [z.id, z]),
 ) as Record<string, Zone>
 
+/**
+ * Offsets dentro de uma zona por índice do agente (0-based).
+ * Valores em % relativo à zona (0–100).
+ * Garante anti-sobreposição para até 3 agentes.
+ */
+const AGENT_ZONE_OFFSETS = [
+  { x: 25, y: 40 }, // agent-1
+  { x: 50, y: 40 }, // agent-2
+  { x: 75, y: 40 }, // agent-3
+]
+
+const DEFAULT_OFFSET = { x: 50, y: 50 }
+
+export interface AgentPosition {
+  /** % from left of the canvas */
+  x: number
+  /** % from top of the canvas */
+  y: number
+}
+
+/**
+ * Calcula a posição absoluta (% do canvas) de um agente dentro de sua zona,
+ * usando o índice do agente para evitar sobreposição.
+ *
+ * @param zoneId   ID da zona onde o agente está
+ * @param agentIndex  Índice 0-based do agente (0=agent-1, 1=agent-2, 2=agent-3)
+ */
+export function getAgentPosition(zoneId: string, agentIndex: number): AgentPosition {
+  const zone = ZONE_BY_ID[zoneId]
+  if (!zone) return { x: 50, y: 50 }
+
+  const offset = AGENT_ZONE_OFFSETS[agentIndex] ?? DEFAULT_OFFSET
+
+  return {
+    x: zone.x + (zone.width * offset.x) / 100,
+    y: zone.y + (zone.height * offset.y) / 100,
+  }
+}
+
 // Cores por agente
 export const AGENT_COLORS: Record<string, string> = {
   'agent-1': '#8b5cf6', // violet  — Claude


### PR DESCRIPTION
## Issue
Closes #11

## O que foi feito

Adicionado `getAgentPosition(zoneId, agentIndex)` em `src/data/office-layout.ts`:

- Calcula posição absoluta **% do canvas** de um agente dentro de sua zona
- Offsets pré-definidos para 3 índices garantem que agentes não se sobreponham na mesma zona
- Offset default `{ x:50, y:50 }` para índices fora do range
- Retorna `{ x:50, y:50 }` para zonas desconhecidas (safe default)
- Expõe tipo `AgentPosition` para uso em `AgentAvatar` (issue #9)

## Testes

6 novos testes em `office-layout.test.ts` → **46 total**

```
✓ src/data/office-layout.test.ts (22 tests)
```

## Checklist
- [x] typecheck passou
- [x] lint passou
- [x] testes passaram