### PR TITLE
docs: atualizar readme e docs com estado real do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,178 @@
 # mago-office
 
-> Virtual office visualization for MAGO agents and human collaborators — 2D workspace with real-time presence.
+> Virtual office 2D para visualização dos agentes MAGO em tempo real.
 
-A feature of the [MAGO platform](https://mago.technology) that adds a **Gather.town-style 2D virtual office** to the Flowday Web interface, showing AI agents and human collaborators interacting in real-time.
+App React standalone estilo Gather.town. Mostra os agentes de IA se movendo entre zonas conforme o status deles, com animações Framer Motion e conexão Socket.io ao backend MAGO.
 
----
-
-## Overview
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                                                                 │
-│  ╔═══════════════╗  ╔══════════════╗  ╔═══════════════════╗   │
-│  ║  DEV ZONE ⚡  ║  ║ REVIEW 👁    ║  ║  PLANNING 📋      ║   │
-│  ║   [agent-3]   ║  ║  [agent-1]   ║  ║                   ║   │
-│  ╚═══════════════╝  ╚══════════════╝  ╚═══════════════════╝   │
-│                                                                 │
-│  ╔═══════════════════════════╗   ╔═══════════════════╗        │
-│  ║     ANALYSIS AREA 🔍     ║   ║  COFFEE ☕         ║        │
-│  ║        [agent-2]          ║   ║                   ║        │
-│  ╚═══════════════════════════╝   ╚═══════════════════╝        │
-│                                                                 │
-│  ─────────────── LOBBY 🚪 ─── [você] ──────────────────────── │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Agentes de IA** se movem automaticamente entre zonas conforme seu `status` e `lastAction`. **Usuários humanos** aparecem como avatares draggáveis. Clicar num agente abre um painel com a task atual e um input para enviar mensagens via Celebro.
+**URL**: https://office.iae.wtf
 
 ---
 
-## Features
+## Mapa do escritório
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  DEV ZONE ⚡         REVIEW ROOM 👁      PLANNING BOARD 📋   │
+│  [implementer]       [code-reviewer]     [planner]           │
+│                                                              │
+│  ANALYSIS AREA 🔍                   COFFEE CORNER ☕         │
+│  [analyzer]                         [idle agents]           │
+│                                                              │
+│  ─────────────────── LOBBY 🚪 ──────────────────────────────│
+│  [offline/blocked agents]    [você — draggable]             │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Agentes se movem automaticamente: `status` + `current_task` → zona.
+
+---
+
+## Status das features
 
 | Feature | Status | Milestone |
 |---------|--------|-----------|
-| Socket presence events | Planejado | v0.1 |
-| Office Map 2D (zones) | Planejado | v0.2 |
-| Agent Avatars animados | Planejado | v0.3 |
-| Human Presence + drag | Planejado | v0.4 |
-| Interactions + messages | Planejado | v0.5 |
+| Scaffold + ESLint + CI | Concluído | v0.1 |
+| Socket.io-client + `useSocket` | Concluído | v0.1 |
+| `office-layout.ts` (6 zonas + `getAgentZone` + `getAgentPosition`) | Concluído | v0.2 |
+| `OfficeCanvas` + `OfficeRoom` + `OfficeHUD` | Concluído | v0.2 |
+| `AgentAvatar.tsx` (animações Framer Motion) | Em desenvolvimento | v0.3 |
+| `SpeechBubble.tsx` (balão de fala) | Em desenvolvimento | v0.3 |
+| `useOfficeState.ts` (estado central REST + socket) | Em desenvolvimento | v0.3 |
+| `HumanAvatar` draggable | Planejado | v0.4 |
+| `AgentDetailPanel` + mensagens Celebro | Planejado | v0.5 |
 | Hacker Mode theme | Planejado | v1.0 |
 
 ---
 
-## Tech Stack
+## Stack
 
-- **Frontend**: React 19 + Vite 6 + Framer Motion 12
-- **Backend**: Express 4 + Socket.io 4 + Prisma 6
-- **State**: Zustand 5 + React hooks
-- **Tests**: Vitest + Playwright
-- **CI**: GitHub Actions
-
----
-
-## Milestones
-
-| Versão | Escopo | Deadline |
-|--------|--------|----------|
-| [v0.1 — Foundation](../../milestone/1) | Socket presence events, `/office/state` endpoint | 15/03/2026 |
-| [v0.2 — Office Map](../../milestone/2) | Layout 2D, zonas, rota `/app/office` | 22/03/2026 |
-| [v0.3 — Agent Avatars](../../milestone/3) | Avatares animados dos 3 agentes | 29/03/2026 |
-| [v0.4 — Human Presence](../../milestone/4) | Avatar humano draggable, broadcast | 05/04/2026 |
-| [v0.5 — Interactions](../../milestone/5) | AgentDetailPanel, mensagens | 12/04/2026 |
-| [v1.0 — Polish](../../milestone/6) | Hacker Mode, testes, CI/CD | 19/04/2026 |
+- **React 19** + **Vite 6** + **TypeScript strict**
+- **Framer Motion** — animações de avatar e transições
+- **socket.io-client** — conexão ao MAGO backend (localhost:3002)
+- **Vitest** + **@testing-library/react** — testes unitários
+- **pnpm** — gerenciador de pacotes
+- **Node 22 LTS**
 
 ---
 
-## Workflow
+## Backend MAGO (referência)
 
-```
-Issue → feat/issue-N-description branch
-    → Código + commits (conventional commits)
-    → PR aberta → base: develop
-    → GitHub Copilot Review (automático)
-    → CI: typecheck + lint + test + build
-    → Human Review (1 aprovação)
-    → Merge → develop
-    → Issue fechada (closes #N)
-```
+O mago-office **não modifica o backend** — apenas consome como cliente.
 
-### Commit Convention
+| Recurso | URL |
+|---------|-----|
+| Agentes | `GET http://localhost:3002/api/dashboard/agents` |
+| Socket.io | `ws://localhost:3002` |
 
-```
-TYPE(SCOPE): descrição
+### Shape do agente (real)
 
-Types: feat, fix, docs, refactor, test, ci, chore
-Scopes: office, backend, socket, animation, ui, dx, ci
-
-Exemplos:
-  feat(office): add AgentAvatar with Framer Motion animations
-  fix(socket): fix memory leak in office:leave handler
-  test(office): add E2E tests for human presence
+```typescript
+interface Agent {
+  id: string           // 'rx-backend', 'rx-architect', 'rx-orchestrator'
+  name: string         // 'Backend', 'Architect', 'Orchestrator'
+  role: string         // 'backend', 'architect', 'orchestrator'
+  status: string       // 'idle' | 'working' | 'thinking' | 'offline' | 'blocked'
+  current_task: string // equivalente a lastAction — ex: 'Aguardando próximo ciclo'
+  progress: number | null
+  last_heartbeat: string // ISO timestamp
+  messages_count: number
+}
 ```
 
-### Branch Naming
+### Eventos socket consumidos
 
-```
-feat/issue-N-short-description
-fix/issue-N-short-description
-```
+| Evento | Direção | Uso |
+|--------|---------|-----|
+| `agent:status:updated` | Backend → Cliente | Atualiza zona do agente |
+| `bus:message` | Backend → Cliente | Dispara SpeechBubble |
+| `office:user:joined` | Backend → Cliente | Adiciona avatar humano |
+| `office:user:left` | Backend → Cliente | Remove avatar humano |
+| `office:user:moved` | Backend → Cliente | Anima avatar humano |
+| `office:join` | Cliente → Backend | Registra presença humana |
+| `office:leave` | Cliente → Backend | Remove presença ao sair |
+| `office:user:move` | Cliente → Backend | Broadcast posição do avatar |
 
 ---
 
-## Setup Local
+## Setup
 
 ```bash
-# As mudanças de código vão no MAGO monorepo em:
-# apps/flowday-web/src/pages/office/
-# apps/flowday-backend/src/routes/office.routes.ts
-# apps/flowday-backend/src/index.ts (socket events)
+# Requisitos: Node 22, pnpm 9+
+nvm use 22
+pnpm install
+pnpm dev         # dev em localhost:3010
+```
+
+```bash
+pnpm typecheck   # tsc --noEmit
+pnpm lint        # eslint
+pnpm test        # vitest run
+pnpm build       # build prod → dist/
 ```
 
 ---
 
-## Agentes MAGO
+## Estrutura
 
-| Agente | Modelo | Role | Cor |
-|--------|--------|------|-----|
-| agent-1 | Claude Sonnet | code-reviewer | #8b5cf6 |
-| agent-2 | Gemini Flash | analyzer | #10b981 |
-| agent-3 | OpenCode | implementer | #f59e0b |
+```
+src/
+├── main.tsx
+├── App.tsx                         ← socket status + OfficeCanvas
+├── services/
+│   └── socket.ts                   ← singleton socket.io-client (autoConnect:false)
+├── data/
+│   └── office-layout.ts            ← 6 zonas, getAgentZone, getAgentPosition
+├── hooks/
+│   ├── useSocket.ts                ← status de conexão (5 estados)
+│   └── useOfficeState.ts           ← estado central (REST + socket) [wip]
+├── components/
+│   ├── OfficeCanvas.tsx            ← container full-screen + grid + HUD
+│   ├── OfficeRoom.tsx              ← zona posicionada por %
+│   ├── OfficeHUD.tsx               ← status de conexão + contagem
+│   ├── AgentAvatar.tsx             ← avatar animado por status [wip]
+│   └── SpeechBubble.tsx            ← balão de fala com auto-dismiss [wip]
+└── constants/
+    └── status.ts                   ← STATUS_COLOR, STATUS_LABEL
+```
 
 ---
 
-## Links
+## Workflow de desenvolvimento
 
-- [Flowday Board](https://mago.technology) — tasks dos agentes
-- [Discussions](../../discussions) — design decisions
-- [Wiki](../../wiki) — documentação técnica
-- [Project Board](https://github.com/users/roxdavirox/projects/2) — status geral
+```
+Issue → scripts/branch-create.sh N
+     → Código + commits (conventional commits em português)
+     → git push → PR para develop
+     → CI: typecheck + lint + test + build
+     → AI Review (self-hosted runner, OpenCode)
+     → Resolver todos os bugs/warnings do review
+     → scripts/pr-merge.sh N → squash merge
+     → Issue fechada → git checkout develop → git pull
+```
+
+### Convenção de commits
+
+```
+tipo(escopo): descrição em português lowercase
+
+feat | fix | refactor | test | chore | ci | docs
+escopo: canvas, avatar, socket, layout, hacker, deploy, scaffold
+```
+
+---
+
+## Agentes
+
+| Agente | ID real | Role | Cor |
+|--------|---------|------|-----|
+| Claude | rx-architect | architect | #8b5cf6 |
+| Gemini | rx-backend | backend | #10b981 |
+| OpenCode | rx-orchestrator | orchestrator | #f59e0b |
+
+---
+
+## Deploy
+
+Merge em `main` → GitHub Actions → SSH VPS → `pnpm build` → nginx serve `dist/`
+
+Nginx config: `/etc/nginx/sites-available/office.iae.wtf`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Visão geral
 
-O `mago-office` é um **app React standalone** que se conecta ao backend MAGO existente como cliente externo. Não modifica o MAGO — apenas consome os eventos Socket.io e endpoints REST já disponíveis.
+O `mago-office` é um **app React standalone** que consome o backend MAGO como cliente externo via Socket.io e REST. Não modifica o MAGO.
 
 ## Diagrama
 
@@ -10,58 +10,116 @@ O `mago-office` é um **app React standalone** que se conecta ao backend MAGO ex
 ┌──────────────────────────────────────────────┐
 │           mago-office (standalone)            │
 │                                              │
-│  React 19 + Vite   →  office.iae.wtf         │
+│  React 19 + Vite 6   →  office.iae.wtf       │
 │                                              │
 │  App.tsx                                     │
-│   └── OfficeCanvas.tsx                       │
-│        ├── OfficeRoom.tsx × 6                │
-│        │    ├── AgentAvatar.tsx              │
-│        │    │    └── SpeechBubble.tsx        │
-│        │    └── HumanAvatar.tsx (draggable)  │
-│        └── AgentDetailPanel.tsx (slide-in)   │
+│   └── OfficeCanvas.tsx         [v0.2 ✓]      │
+│        ├── OfficeRoom.tsx × 6  [v0.2 ✓]      │
+│        │    ├── AgentAvatar.tsx         [wip] │
+│        │    │    └── SpeechBubble.tsx   [wip] │
+│        │    └── HumanAvatar.tsx (drag)  [v0.4]│
+│        ├── OfficeHUD.tsx        [v0.2 ✓]      │
+│        └── AgentDetailPanel.tsx         [v0.5]│
 │                                              │
-│  hooks/useOfficeState.ts                     │
-│   ├── REST: GET /api/dashboard/agents        │
-│   └── Socket.io: agent:status:updated        │
-│                  bus:message                 │
-│                  office:user:*               │
+│  hooks/                                      │
+│   ├── useSocket.ts       [v0.1 ✓]            │
+│   └── useOfficeState.ts                [wip] │
+│                                              │
+│  data/office-layout.ts   [v0.2 ✓]            │
+│   ├── OFFICE_ZONES (6 zonas)                 │
+│   ├── getAgentZone(status, current_task)      │
+│   └── getAgentPosition(zoneId, agentIndex)    │
+│                                              │
+│  constants/status.ts     [v0.2 ✓]            │
 └──────────────────┬───────────────────────────┘
-                   │  Socket.io-client
-                   │  REST (fetch)
+                   │  socket.io-client (autoConnect:false)
+                   │  fetch REST
                    ▼
 ┌──────────────────────────────────────────────┐
-│        MAGO Backend (localhost:3002)          │
+│     MAGO Backend (localhost:3002)             │
 │                                              │
-│  Eventos emitidos (já existentes):           │
+│  REST endpoints consumidos:                  │
+│  • GET /api/dashboard/agents                 │
+│                                              │
+│  Eventos socket emitidos pelo backend:       │
 │  • agent:status:updated                      │
 │  • bus:message                               │
-│  • board:item:moved                          │
-│  • office:user:joined / moved / left         │
 │                                              │
-│  Endpoints REST:                             │
-│  • GET /api/dashboard/agents                 │
-│  • POST /api/office/join (emite para room)   │
+│  Eventos socket de presença humana:          │
+│  • office:user:joined / moved / left         │
 └──────────────────────────────────────────────┘
 ```
 
-## Fluxo de dados
+## Shape real do agente (GET /api/dashboard/agents)
 
-### Carga inicial
-1. App monta → `useOfficeState` chama `GET /api/dashboard/agents`
-2. Retorna snapshot dos 3 agentes com status + lastAction
-3. `getAgentZone(status, lastAction)` calcula zona de cada agente
-4. Socket conecta e emite `office:join` com userId do usuário humano
-5. Backend broadcast `office:user:joined` → outros clientes recebem
+```typescript
+interface Agent {
+  id: string           // 'rx-backend' | 'rx-architect' | 'rx-orchestrator'
+  name: string         // 'Backend' | 'Architect' | 'Orchestrator'
+  role: string         // 'backend' | 'architect' | 'orchestrator'
+  status: string       // 'idle' | 'working' | 'thinking' | 'offline' | 'blocked'
+  current_task: string // ex: 'Aguardando próximo ciclo' (equivalente a lastAction)
+  progress: number | null
+  last_heartbeat: string
+  messages_count: number
+}
+```
 
-### Atualização de agente em tempo real
-1. MAGO agent muda de estado → backend emite `agent:status:updated`
-2. `useOfficeState` recebe → recalcula zona
-3. `AgentAvatar` anima transição (Framer Motion `layoutId`)
+> **Nota:** o campo `lastAction` mencionado em issues anteriores corresponde ao `current_task` da API real.
 
-### Movimentação humana
-1. Usuário arrasta `HumanAvatar`
-2. `onDragEnd` emite `office:user:move` com `{ x, y }`
-3. Outros clientes recebem `office:user:moved` e animam
+## Mapeamento de zona
+
+`getAgentZone(status, current_task)` em `src/data/office-layout.ts`:
+
+| status | current_task | zona |
+|--------|-------------|------|
+| `idle` | qualquer | `coffee-corner` |
+| `offline` / `blocked` | qualquer | `lobby` |
+| null / undefined | qualquer | `lobby` |
+| `working` / `thinking` | inclui "review" / "revisando" / "aprovando" | `review-room` |
+| `working` / `thinking` | inclui "plan" / "task" / "sprint" / "backlog" | `planning-board` |
+| `working` / `thinking` | inclui "analyz" / "analis" / "inspect" / "debug" | `analysis-area` |
+| `working` / `thinking` | outros | `dev-zone` |
+
+## Posicionamento anti-sobreposição
+
+`getAgentPosition(zoneId, agentIndex)` retorna `{ x, y }` em % do canvas:
+
+- Índice 0 (rx-architect / Claude): offset `{ x:25%, y:40% }` dentro da zona
+- Índice 1 (rx-backend / Gemini): offset `{ x:50%, y:40% }`
+- Índice 2 (rx-orchestrator / OpenCode): offset `{ x:75%, y:40% }`
+
+## Fluxo de dados — carga inicial
+
+```
+App monta
+  → useOfficeState
+  → GET /api/dashboard/agents
+  → para cada agente: getAgentZone(status, current_task) → zoneId
+  → getAgentPosition(zoneId, agentIndex) → { x, y }
+  → renderiza AgentAvatar na posição calculada
+```
+
+## Fluxo de dados — atualização em tempo real
+
+```
+MAGO agent muda estado
+  → backend emite agent:status:updated { agentId, status, lastAction }
+  → useOfficeState recebe
+  → recalcula zona
+  → AgentAvatar anima para nova posição (Framer Motion layoutId)
+```
+
+## Fluxo de dados — presença humana
+
+```
+Usuário abre office.iae.wtf
+  → socket conecta → emite office:join { userId, name }
+  → backend broadcast office:user:joined para outros clientes
+  → usuário arrasta HumanAvatar
+  → onDragEnd emite office:user:move { x, y }
+  → outros recebem office:user:moved e animam
+```
 
 ## Estrutura de arquivos
 
@@ -70,34 +128,37 @@ mago-office/
 ├── src/
 │   ├── main.tsx
 │   ├── App.tsx
-│   ├── HackerMode.tsx
-│   ├── services/
-│   │   └── socket.ts              ← conexão Socket.io-client
-│   ├── data/
-│   │   └── office-layout.ts       ← zonas + getAgentZone()
+│   ├── services/socket.ts            ← singleton, autoConnect:false
+│   ├── data/office-layout.ts         ← zonas + lógica de posicionamento
 │   ├── hooks/
-│   │   ├── useOfficeState.ts      ← estado central (REST + socket)
-│   │   └── useHackerMode.ts
-│   └── components/
-│       ├── OfficeCanvas.tsx
-│       ├── OfficeRoom.tsx
-│       ├── AgentAvatar.tsx
-│       ├── SpeechBubble.tsx
-│       ├── HumanAvatar.tsx
-│       └── AgentDetailPanel.tsx
-├── index.html
-├── vite.config.ts
-├── tsconfig.json
-├── package.json
-└── .github/
-    └── workflows/
-        ├── ci.yml                 ← typecheck + lint + test + build
-        └── deploy.yml             ← SSH → VPS → nginx office.iae.wtf
+│   │   ├── useSocket.ts              ← 5 estados de conexão
+│   │   └── useOfficeState.ts         ← estado central [wip]
+│   ├── components/
+│   │   ├── OfficeCanvas.tsx          ← canvas full-screen
+│   │   ├── OfficeRoom.tsx            ← zona individual
+│   │   ├── OfficeHUD.tsx             ← status bar
+│   │   ├── AgentAvatar.tsx           ← [wip]
+│   │   ├── SpeechBubble.tsx          ← [wip]
+│   │   ├── HumanAvatar.tsx           ← [v0.4]
+│   │   └── AgentDetailPanel.tsx      ← [v0.5]
+│   └── constants/
+│       └── status.ts                 ← STATUS_COLOR, STATUS_LABEL
+├── .github/workflows/
+│   ├── ci.yml                        ← typecheck + lint + test + build
+│   ├── deploy.yml                    ← push main → SSH → pnpm build
+│   └── ai-review.yml                 ← self-hosted runner, OpenCode
+└── scripts/
+    ├── branch-create.sh
+    ├── pr-create.sh
+    ├── pr-check.sh
+    ├── pr-merge.sh
+    └── pr-review.sh
 ```
 
 ## Deploy
 
 - **URL**: https://office.iae.wtf
-- **VPS**: 147.79.111.174 — `/home/rx/lab/mago-office/dist/`
+- **VPS**: `/home/rx/lab/mago-office/dist/`
 - **Trigger**: push em `main` → GitHub Actions → SSH → `pnpm build` → nginx
 - **Nginx**: serve `dist/` com `try_files $uri /index.html` (SPA)
+- **Runner CI**: self-hosted `vps-mago-office` em `/home/rx/actions-runner-mago-office/`

--- a/docs/socket-protocol.md
+++ b/docs/socket-protocol.md
@@ -1,120 +1,69 @@
 # Socket Protocol
 
-## Eventos de Office (novos)
+Conexão: `ws://localhost:3002` via `socket.io-client`.
+O socket usa `autoConnect: false` — conectado manualmente via `connectSocket()` ao montar.
 
-### Cliente → Servidor
+## Eventos consumidos (Backend → Cliente)
 
-| Evento | Payload | Descrição |
-|--------|---------|-----------|
-| `office:join` | `{ userId: string, name: string }` | Usuário entra na Office View |
-| `office:user:move` | `{ x: number, y: number }` | Usuário move seu avatar (0-100%) |
-| `office:leave` | _(sem payload)_ | Usuário sai da Office View |
+| Evento | Payload | Uso |
+|--------|---------|-----|
+| `agent:status:updated` | `{ agentId, status, lastAction, timestamp }` | Recalcula zona do agente |
+| `bus:message` | `{ from, type, payload: { content? }, timestamp }` | Dispara SpeechBubble no agente sender |
+| `office:user:joined` | `{ socketId, userId, name, x, y }` | Adiciona avatar humano |
+| `office:user:left` | `{ socketId }` | Remove avatar humano |
+| `office:user:moved` | `{ socketId, x, y }` | Anima avatar humano para nova posição |
 
-### Servidor → Cliente
+## Eventos emitidos (Cliente → Backend)
 
-| Evento | Payload | Descrição |
-|--------|---------|-----------|
-| `office:state` | `{ agents: Agent[], users: User[] }` | Snapshot inicial (emitido ao `office:join`) |
-| `office:user:joined` | `{ socketId, userId, name, x, y }` | Novo usuário entrou |
-| `office:user:left` | `{ socketId }` | Usuário saiu |
-| `office:user:moved` | `{ socketId, x, y }` | Usuário moveu avatar |
+| Evento | Payload | Quando |
+|--------|---------|--------|
+| `office:join` | `{ userId: string, name: string }` | Ao montar a Office View |
+| `office:leave` | _(sem payload)_ | Ao desmontar / fechar aba |
+| `office:user:move` | `{ x: number, y: number }` | `onDragEnd` do HumanAvatar |
 
-## Eventos existentes (reutilizados)
-
-| Evento | Quem emite | Uso na Office View |
-|--------|-----------|-------------------|
-| `agent:status:updated` | Backend | Atualiza zona do agente |
-| `bus:message` | Backend | Dispara SpeechBubble |
-| `board:item:moved` | Backend | Indicador de trabalho |
-
-## Schemas completos
+## Schemas TypeScript
 
 ```typescript
-// office:state (payload)
-interface OfficeStatePayload {
-  agents: Array<{
-    id: string           // 'rx-agent-1'
-    name: string         // 'Agent 1'
-    role: string         // 'code-reviewer'
-    status: string       // 'working' | 'idle' | 'blocked' | 'offline'
-    lastAction: string   // 'Moving task #47 to Done'
-    zone: string         // 'dev-zone'
-    color: string        // '#8b5cf6'
-  }>
-  users: Array<{
-    socketId: string
-    userId: string
-    name: string
-    x: number           // 0-100 (% do canvas)
-    y: number           // 0-100
-    joinedAt: string    // ISO timestamp
-  }>
-}
-
-// agent:status:updated (payload existente)
-interface AgentStatusEvent {
+// agent:status:updated
+interface AgentStatusUpdated {
   agentId: string
   status: string
-  lastAction: string
+  lastAction: string   // equivalente a current_task na REST API
   timestamp: string
 }
 
-// bus:message (payload existente)
+// bus:message
 interface BusMessage {
   from: string
   type: string
   payload: { content?: string; [key: string]: unknown }
   timestamp: string
 }
+
+// office:user:joined / office:user:moved
+interface OfficeUserJoined {
+  socketId: string
+  userId: string
+  name: string
+  x: number   // 0–100 (% do canvas)
+  y: number
+  joinedAt?: string
+}
+
+interface OfficeUserMoved {
+  socketId: string
+  x: number
+  y: number
+}
+
+interface OfficeUserLeft {
+  socketId: string
+}
 ```
 
-## Validações no servidor
+## Notas de implementação
 
-- `x` e `y` devem ser números entre 0 e 100
-- Rate limit: 1 evento `office:user:move` por 50ms por socket
-- Máximo de 50 usuários simultâneos na room `office:view`
-- Cleanup automático de usuário ao `disconnect`
-
-## Exemplo de implementação (backend)
-
-```typescript
-// index.ts
-const officeUsers = new Map<string, OfficeUser>()
-
-socket.on('office:join', ({ userId, name }) => {
-  socket.join('office:view')
-  const user = { socketId: socket.id, userId, name, x: 50, y: 88, joinedAt: new Date() }
-  officeUsers.set(socket.id, user)
-  
-  // Snapshot para o novo usuário
-  socket.emit('office:state', {
-    agents: await getAgentStates(),
-    users: Array.from(officeUsers.values())
-  })
-  
-  // Broadcast para os outros
-  socket.to('office:view').emit('office:user:joined', user)
-})
-
-socket.on('office:user:move', ({ x, y }) => {
-  if (x < 0 || x > 100 || y < 0 || y > 100) return
-  const user = officeUsers.get(socket.id)
-  if (!user) return
-  user.x = x
-  user.y = y
-  socket.to('office:view').emit('office:user:moved', { socketId: socket.id, x, y })
-})
-
-socket.on('office:leave', () => {
-  socket.leave('office:view')
-  officeUsers.delete(socket.id)
-  io.to('office:view').emit('office:user:left', { socketId: socket.id })
-})
-
-socket.on('disconnect', () => {
-  if (officeUsers.has(socket.id)) {
-    officeUsers.delete(socket.id)
-    io.to('office:view').emit('office:user:left', { socketId: socket.id })
-  }
-})
-```
+- Rate limit sugerido: 1 evento `office:user:move` por 50ms por socket
+- `x` e `y` devem estar entre 0 e 100
+- Cleanup no unmount: `socket.emit('office:leave')` + remover listeners
+- Não usar `socket.disconnect()` no unmount — a instância é singleton reutilizada


### PR DESCRIPTION
## O que foi feito

Atualização das docs para refletir o estado real do projeto após v0.1 e v0.2.

### README.md
- Feature table com status atual (concluído / wip / planejado)
- Shape real do agente (`current_task` em vez de `lastAction`, ids `rx-*`)
- Tabela de agentes reais (rx-architect, rx-backend, rx-orchestrator)
- Estrutura de arquivos atualizada

### docs/architecture.md
- Diagrama com componentes marcados como ✓ vs wip
- Shape real da API (GET /api/dashboard/agents)
- Nota explícita: `lastAction` → `current_task` na API real
- Fluxos de dados detalhados

### docs/socket-protocol.md
- Simplificado para eventos reais conhecidos
- Schemas TypeScript corretos
- Notas de implementação (rate limit, cleanup, singleton)