### PR TITLE
feat(socket): useofficestate.ts — estado central de agentes e usuarios

### DIFF
--- a/src/data/office-layout.test.ts
+++ b/src/data/office-layout.test.ts
@@ -48,9 +48,9 @@ describe('ZONE_BY_ID', () => {
 
 describe('getAgentColor', () => {
   it('retorna cor correta para agentes conhecidos', () => {
-    expect(getAgentColor('agent-1')).toBe(AGENT_COLORS['agent-1'])
-    expect(getAgentColor('agent-2')).toBe(AGENT_COLORS['agent-2'])
-    expect(getAgentColor('agent-3')).toBe(AGENT_COLORS['agent-3'])
+    expect(getAgentColor('rx-architect')).toBe(AGENT_COLORS['rx-architect'])
+    expect(getAgentColor('rx-backend')).toBe(AGENT_COLORS['rx-backend'])
+    expect(getAgentColor('rx-orchestrator')).toBe(AGENT_COLORS['rx-orchestrator'])
   })
 
   it('retorna cor default para agente desconhecido', () => {

--- a/src/data/office-layout.ts
+++ b/src/data/office-layout.ts
@@ -71,9 +71,9 @@ export const ZONE_BY_ID = Object.fromEntries(
  * Garante anti-sobreposição para até 3 agentes.
  */
 const AGENT_ZONE_OFFSETS = [
-  { x: 25, y: 40 }, // agent-1
-  { x: 50, y: 40 }, // agent-2
-  { x: 75, y: 40 }, // agent-3
+  { x: 25, y: 40 }, // rx-architect (Claude)
+  { x: 50, y: 40 }, // rx-backend   (Gemini)
+  { x: 75, y: 40 }, // rx-orchestrator (OpenCode)
 ]
 
 const DEFAULT_OFFSET = { x: 50, y: 50 }
@@ -104,11 +104,14 @@ export function getAgentPosition(zoneId: string, agentIndex: number): AgentPosit
   }
 }
 
-// Cores por agente
+/**
+ * Cores por agente — chaves são os IDs reais da API (GET /api/dashboard/agents).
+ * A ordem define o índice de posicionamento anti-sobreposição (0, 1, 2).
+ */
 export const AGENT_COLORS: Record<string, string> = {
-  'agent-1': '#8b5cf6', // violet  — Claude
-  'agent-2': '#10b981', // emerald — Gemini
-  'agent-3': '#f59e0b', // amber   — OpenCode
+  'rx-architect':    '#8b5cf6', // violet  — Claude
+  'rx-backend':      '#10b981', // emerald — Gemini
+  'rx-orchestrator': '#f59e0b', // amber   — OpenCode
 }
 
 export const DEFAULT_AGENT_COLOR = '#6b7280'

--- a/src/hooks/useOfficeState.test.ts
+++ b/src/hooks/useOfficeState.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { RawAgent } from './useOfficeState'
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const socketListeners = vi.hoisted(() => new Map<string, (...args: unknown[]) => void>())
+
+const mockSocket = vi.hoisted(() => ({
+  on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+    socketListeners.set(event, cb)
+  }),
+  off: vi.fn((event: string) => {
+    socketListeners.delete(event)
+  }),
+}))
+
+vi.mock('../services/socket', () => ({
+  getSocket: () => mockSocket,
+  socket: mockSocket,
+  connectSocket: vi.fn(),
+}))
+
+const mockAgents: RawAgent[] = [
+  {
+    id: 'rx-architect',
+    name: 'Architect',
+    role: 'architect',
+    status: 'idle',
+    current_task: 'Aguardando próximo ciclo',
+    progress: null,
+    last_heartbeat: '2026-03-01T00:00:00Z',
+    messages_count: 0,
+  },
+  {
+    id: 'rx-backend',
+    name: 'Backend',
+    role: 'backend',
+    status: 'working',
+    current_task: 'implementando feature X',
+    progress: null,
+    last_heartbeat: '2026-03-01T00:00:01Z',
+    messages_count: 2,
+  },
+  {
+    id: 'rx-orchestrator',
+    name: 'Orchestrator',
+    role: 'orchestrator',
+    status: 'thinking',
+    current_task: 'revisando código',
+    progress: null,
+    last_heartbeat: '2026-03-01T00:00:02Z',
+    messages_count: 1,
+  },
+]
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  socketListeners.clear()
+  mockSocket.on.mockClear()
+  mockSocket.off.mockClear()
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockAgents),
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+const { useOfficeState } = await import('./useOfficeState')
+
+describe('useOfficeState — carga inicial', () => {
+  it('começa em estado de loading e termina sem erro', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    // Estado inicial: loading=true, agents vazio
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.agents).toHaveLength(0)
+    // Após fetch resolver: loading=false, agents preenchidos
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeNull()
+  })
+
+  it('carrega agentes da API e calcula zona/posição', async () => {
+    const { result } = renderHook(() => useOfficeState())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.agents).toHaveLength(3)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('agente idle vai para coffee-corner', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const architect = result.current.agents.find(a => a.id === 'rx-architect')
+    expect(architect?.zoneId).toBe('coffee-corner')
+  })
+
+  it('agente working sem action específica vai para dev-zone', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const backend = result.current.agents.find(a => a.id === 'rx-backend')
+    expect(backend?.zoneId).toBe('dev-zone')
+  })
+
+  it('agente thinking com review action vai para review-room', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const orchestrator = result.current.agents.find(a => a.id === 'rx-orchestrator')
+    expect(orchestrator?.zoneId).toBe('review-room')
+  })
+
+  it('agentes têm posição calculada (x e y são números)', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    for (const agent of result.current.agents) {
+      expect(typeof agent.position.x).toBe('number')
+      expect(typeof agent.position.y).toBe('number')
+    }
+  })
+
+  it('mapeia currentTask a partir de current_task da API', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const backend = result.current.agents.find(a => a.id === 'rx-backend')
+    expect(backend?.currentTask).toBe('implementando feature X')
+  })
+
+  it('speechText começa como null', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    for (const agent of result.current.agents) {
+      expect(agent.speechText).toBeNull()
+    }
+  })
+})
+
+describe('useOfficeState — erro na API', () => {
+  it('define error e sai do loading quando fetch falha', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    )
+
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).toMatch(/500/)
+    expect(result.current.agents).toHaveLength(0)
+  })
+})
+
+describe('useOfficeState — eventos socket', () => {
+  it('atualiza zona do agente ao receber agent:status:updated', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      const handler = socketListeners.get('agent:status:updated')
+      handler?.({ agentId: 'rx-architect', status: 'working', lastAction: 'revisando PR #12' })
+    })
+
+    const architect = result.current.agents.find(a => a.id === 'rx-architect')
+    expect(architect?.zoneId).toBe('review-room')
+    expect(architect?.status).toBe('working')
+  })
+
+  it('exibe speechText ao receber bus:message', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      const handler = socketListeners.get('bus:message')
+      handler?.({ from: 'rx-backend', payload: { content: 'Iniciando análise' } })
+    })
+
+    const backend = result.current.agents.find(a => a.id === 'rx-backend')
+    expect(backend?.speechText).toBe('Iniciando análise')
+  })
+
+  it('bus:message sem content não altera speechText', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      const handler = socketListeners.get('bus:message')
+      handler?.({ from: 'rx-backend', payload: {} })
+    })
+
+    const backend = result.current.agents.find(a => a.id === 'rx-backend')
+    expect(backend?.speechText).toBeNull()
+  })
+
+  it('limpa speechText após 5 segundos', async () => {
+    // Carregar antes de ativar fake timers (evita conflito com waitFor/fetch)
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    vi.useFakeTimers()
+
+    act(() => {
+      const handler = socketListeners.get('bus:message')
+      handler?.({ from: 'rx-backend', payload: { content: 'Trabalhando...' } })
+    })
+
+    expect(result.current.agents.find(a => a.id === 'rx-backend')?.speechText).toBe('Trabalhando...')
+
+    act(() => { vi.advanceTimersByTime(5000) })
+
+    expect(result.current.agents.find(a => a.id === 'rx-backend')?.speechText).toBeNull()
+  })
+
+  it('adiciona usuário ao receber office:user:joined', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      const handler = socketListeners.get('office:user:joined')
+      handler?.({ socketId: 'abc123', userId: 'user-1', name: 'Alice', x: 50, y: 88 })
+    })
+
+    expect(result.current.users).toHaveLength(1)
+    expect(result.current.users[0].name).toBe('Alice')
+  })
+
+  it('remove usuário ao receber office:user:left', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      socketListeners.get('office:user:joined')?.({ socketId: 'abc123', userId: 'user-1', name: 'Alice', x: 50, y: 88 })
+    })
+    act(() => {
+      socketListeners.get('office:user:left')?.({ socketId: 'abc123' })
+    })
+
+    expect(result.current.users).toHaveLength(0)
+  })
+
+  it('atualiza posição do usuário ao receber office:user:moved', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      socketListeners.get('office:user:joined')?.({ socketId: 'abc123', userId: 'user-1', name: 'Alice', x: 50, y: 88 })
+    })
+    act(() => {
+      socketListeners.get('office:user:moved')?.({ socketId: 'abc123', x: 30, y: 60 })
+    })
+
+    const user = result.current.users.find(u => u.socketId === 'abc123')
+    expect(user?.x).toBe(30)
+    expect(user?.y).toBe(60)
+  })
+})
+
+describe('useOfficeState — cleanup', () => {
+  it('remove listeners do socket ao desmontar', async () => {
+    const { result, unmount } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    unmount()
+
+    expect(mockSocket.off).toHaveBeenCalledWith('agent:status:updated', expect.any(Function))
+    expect(mockSocket.off).toHaveBeenCalledWith('bus:message', expect.any(Function))
+    expect(mockSocket.off).toHaveBeenCalledWith('office:user:joined', expect.any(Function))
+    expect(mockSocket.off).toHaveBeenCalledWith('office:user:left', expect.any(Function))
+    expect(mockSocket.off).toHaveBeenCalledWith('office:user:moved', expect.any(Function))
+  })
+})

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -269,11 +269,12 @@ export function useOfficeState(): OfficeState {
 
   // ── Cleanup de timers ao desmontar ───────────────────────────────────────
   useEffect(() => {
+    const timers = speechTimers.current
     return () => {
-      for (const timer of speechTimers.current.values()) {
+      for (const timer of timers.values()) {
         clearTimeout(timer)
       }
-      speechTimers.current.clear()
+      timers.clear()
     }
   }, [])
 

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -1,5 +1,6 @@
 import { useEffect, useReducer, useCallback, useRef } from 'react'
 import { getSocket } from '../services/socket'
+import type { AgentStatus as SocketAgentStatus, BusMessage as SocketBusMessage, OfficeUser } from '../services/socket'
 import {
   getAgentZone,
   getAgentPosition,
@@ -88,7 +89,7 @@ type Action =
   | { type: 'AGENT_STATUS_UPDATED'; agentId: string; status: string; lastAction: string }
   | { type: 'AGENT_SPEECH'; agentId: string; text: string }
   | { type: 'AGENT_SPEECH_CLEAR'; agentId: string }
-  | { type: 'USER_JOINED'; user: UserOfficeData }
+  | { type: 'USER_JOINED'; user: OfficeUser }
   | { type: 'USER_LEFT'; socketId: string }
   | { type: 'USER_MOVED'; socketId: string; x: number; y: number }
   | { type: 'FETCH_ERROR'; error: string }
@@ -222,26 +223,23 @@ export function useOfficeState(): OfficeState {
   useEffect(() => {
     const socket = getSocket()
 
-    const onAgentStatus = (data: { agentId: string; status: string; lastAction: string }) => {
+    const onAgentStatus = (data: SocketAgentStatus) => {
       dispatch({
         type: 'AGENT_STATUS_UPDATED',
         agentId: data.agentId,
         status: data.status,
-        lastAction: data.lastAction ?? '',
+        lastAction: data.lastAction ?? data.currentTask ?? '',
       })
     }
 
-    const onBusMessage = (data: {
-      from: string
-      payload?: { content?: string }
-    }) => {
-      const text = data.payload?.content ?? ''
+    const onBusMessage = (data: SocketBusMessage) => {
+      const text = (data.payload['content'] as string | undefined) ?? ''
       if (!text) return
       dispatch({ type: 'AGENT_SPEECH', agentId: data.from, text })
       scheduleSpeechClear(data.from)
     }
 
-    const onUserJoined = (user: UserOfficeData) => {
+    const onUserJoined = (user: OfficeUser) => {
       dispatch({ type: 'USER_JOINED', user })
     }
 

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -1,0 +1,281 @@
+import { useEffect, useReducer, useCallback, useRef } from 'react'
+import { getSocket } from '../services/socket'
+import {
+  getAgentZone,
+  getAgentPosition,
+  getAgentColor,
+  AGENT_COLORS,
+} from '../data/office-layout'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Shape real da API GET /api/dashboard/agents */
+export interface RawAgent {
+  id: string
+  name: string
+  role: string
+  status: string
+  current_task: string
+  progress: number | null
+  last_heartbeat: string
+  messages_count: number
+}
+
+/** Agente enriquecido com dados de posição calculados */
+export interface AgentOfficeData {
+  id: string
+  name: string
+  role: string
+  status: string
+  /** current_task da API — equivalente a lastAction */
+  currentTask: string
+  zoneId: string
+  /** Posição absoluta em % do canvas */
+  position: { x: number; y: number }
+  color: string
+  /** Texto do SpeechBubble atual (nulo = oculto) */
+  speechText: string | null
+}
+
+export interface UserOfficeData {
+  socketId: string
+  userId: string
+  name: string
+  x: number
+  y: number
+}
+
+export interface OfficeState {
+  agents: AgentOfficeData[]
+  users: UserOfficeData[]
+  isLoading: boolean
+  error: string | null
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const AGENT_IDS_ORDERED = Object.keys(AGENT_COLORS) // ['rx-architect', 'rx-backend', 'rx-orchestrator']
+
+/**
+ * Determina o índice estável do agente para cálculo de offset anti-sobreposição.
+ * Usa a posição do id na lista ordenada; ids desconhecidos vão para o final.
+ */
+function agentIndex(id: string): number {
+  const idx = AGENT_IDS_ORDERED.indexOf(id)
+  return idx >= 0 ? idx : AGENT_IDS_ORDERED.length
+}
+
+function enrichAgent(raw: RawAgent): AgentOfficeData {
+  const zoneId = getAgentZone(raw.status, raw.current_task)
+  const position = getAgentPosition(zoneId, agentIndex(raw.id))
+  return {
+    id: raw.id,
+    name: raw.name,
+    role: raw.role,
+    status: raw.status,
+    currentTask: raw.current_task,
+    zoneId,
+    position,
+    color: getAgentColor(raw.id),
+    speechText: null,
+  }
+}
+
+// ─── Reducer ────────────────────────────────────────────────────────────────
+
+type Action =
+  | { type: 'AGENTS_LOADED'; agents: RawAgent[] }
+  | { type: 'AGENT_STATUS_UPDATED'; agentId: string; status: string; lastAction: string }
+  | { type: 'AGENT_SPEECH'; agentId: string; text: string }
+  | { type: 'AGENT_SPEECH_CLEAR'; agentId: string }
+  | { type: 'USER_JOINED'; user: UserOfficeData }
+  | { type: 'USER_LEFT'; socketId: string }
+  | { type: 'USER_MOVED'; socketId: string; x: number; y: number }
+  | { type: 'FETCH_ERROR'; error: string }
+
+function reducer(state: OfficeState, action: Action): OfficeState {
+  switch (action.type) {
+    case 'AGENTS_LOADED':
+      return {
+        ...state,
+        isLoading: false,
+        error: null,
+        agents: action.agents.map(enrichAgent),
+      }
+
+    case 'AGENT_STATUS_UPDATED':
+      return {
+        ...state,
+        agents: state.agents.map(a => {
+          if (a.id !== action.agentId) return a
+          const raw: RawAgent = {
+            id: a.id,
+            name: a.name,
+            role: a.role,
+            status: action.status,
+            current_task: action.lastAction,
+            progress: null,
+            last_heartbeat: new Date().toISOString(),
+            messages_count: 0,
+          }
+          return { ...enrichAgent(raw), speechText: a.speechText }
+        }),
+      }
+
+    case 'AGENT_SPEECH':
+      return {
+        ...state,
+        agents: state.agents.map(a =>
+          a.id === action.agentId ? { ...a, speechText: action.text } : a,
+        ),
+      }
+
+    case 'AGENT_SPEECH_CLEAR':
+      return {
+        ...state,
+        agents: state.agents.map(a =>
+          a.id === action.agentId ? { ...a, speechText: null } : a,
+        ),
+      }
+
+    case 'USER_JOINED':
+      return {
+        ...state,
+        users: [...state.users.filter(u => u.socketId !== action.user.socketId), action.user],
+      }
+
+    case 'USER_LEFT':
+      return {
+        ...state,
+        users: state.users.filter(u => u.socketId !== action.socketId),
+      }
+
+    case 'USER_MOVED':
+      return {
+        ...state,
+        users: state.users.map(u =>
+          u.socketId === action.socketId ? { ...u, x: action.x, y: action.y } : u,
+        ),
+      }
+
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.error }
+
+    default:
+      return state
+  }
+}
+
+const INITIAL_STATE: OfficeState = {
+  agents: [],
+  users: [],
+  isLoading: true,
+  error: null,
+}
+
+// ─── Hook ───────────────────────────────────────────────────────────────────
+
+const AGENTS_URL = 'http://localhost:3002/api/dashboard/agents'
+
+export function useOfficeState(): OfficeState {
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  // Manter refs de timers de speech bubble por agente para cleanup
+  const speechTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const scheduleSpeechClear = useCallback((agentId: string) => {
+    const existing = speechTimers.current.get(agentId)
+    if (existing) clearTimeout(existing)
+    const timer = setTimeout(() => {
+      dispatch({ type: 'AGENT_SPEECH_CLEAR', agentId })
+      speechTimers.current.delete(agentId)
+    }, 5000)
+    speechTimers.current.set(agentId, timer)
+  }, [])
+
+  // ── Carga inicial via REST ───────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false
+
+    fetch(AGENTS_URL)
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json() as Promise<RawAgent[]>
+      })
+      .then(agents => {
+        if (!cancelled) dispatch({ type: 'AGENTS_LOADED', agents })
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : String(err)
+          dispatch({ type: 'FETCH_ERROR', error: msg })
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // ── Socket events ────────────────────────────────────────────────────────
+  useEffect(() => {
+    const socket = getSocket()
+
+    const onAgentStatus = (data: { agentId: string; status: string; lastAction: string }) => {
+      dispatch({
+        type: 'AGENT_STATUS_UPDATED',
+        agentId: data.agentId,
+        status: data.status,
+        lastAction: data.lastAction ?? '',
+      })
+    }
+
+    const onBusMessage = (data: {
+      from: string
+      payload?: { content?: string }
+    }) => {
+      const text = data.payload?.content ?? ''
+      if (!text) return
+      dispatch({ type: 'AGENT_SPEECH', agentId: data.from, text })
+      scheduleSpeechClear(data.from)
+    }
+
+    const onUserJoined = (user: UserOfficeData) => {
+      dispatch({ type: 'USER_JOINED', user })
+    }
+
+    const onUserLeft = (data: { socketId: string }) => {
+      dispatch({ type: 'USER_LEFT', socketId: data.socketId })
+    }
+
+    const onUserMoved = (data: { socketId: string; x: number; y: number }) => {
+      dispatch({ type: 'USER_MOVED', socketId: data.socketId, x: data.x, y: data.y })
+    }
+
+    socket.on('agent:status:updated', onAgentStatus)
+    socket.on('bus:message', onBusMessage)
+    socket.on('office:user:joined', onUserJoined)
+    socket.on('office:user:left', onUserLeft)
+    socket.on('office:user:moved', onUserMoved)
+
+    return () => {
+      socket.off('agent:status:updated', onAgentStatus)
+      socket.off('bus:message', onBusMessage)
+      socket.off('office:user:joined', onUserJoined)
+      socket.off('office:user:left', onUserLeft)
+      socket.off('office:user:moved', onUserMoved)
+    }
+  }, [scheduleSpeechClear])
+
+  // ── Cleanup de timers ao desmontar ───────────────────────────────────────
+  useEffect(() => {
+    return () => {
+      for (const timer of speechTimers.current.values()) {
+        clearTimeout(timer)
+      }
+      speechTimers.current.clear()
+    }
+  }, [])
+
+  return state
+}

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -175,7 +175,8 @@ const INITIAL_STATE: OfficeState = {
 
 // ─── Hook ───────────────────────────────────────────────────────────────────
 
-const AGENTS_URL = 'http://localhost:3002/api/dashboard/agents'
+const BACKEND_URL = import.meta.env.VITE_MAGO_BACKEND_URL ?? 'http://localhost:3002'
+const AGENTS_URL = `${BACKEND_URL}/api/dashboard/agents`
 
 export function useOfficeState(): OfficeState {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -29,8 +29,9 @@ export interface BoardItemMoved {
 }
 
 export interface OfficeUser {
+  socketId: string
   userId: string
-  displayName: string
+  name: string
   x: number
   y: number
 }
@@ -42,13 +43,13 @@ export interface ServerToClientEvents {
   'bus:message': (data: BusMessage) => void
   'board:item:moved': (data: BoardItemMoved) => void
   'office:user:joined': (data: OfficeUser) => void
-  'office:user:moved': (data: OfficeUser) => void
-  'office:user:left': (data: Pick<OfficeUser, 'userId'>) => void
+  'office:user:moved': (data: { socketId: string; x: number; y: number }) => void
+  'office:user:left': (data: { socketId: string }) => void
 }
 
 export interface ClientToServerEvents {
-  'office:join': (data: Omit<OfficeUser, 'userId'> & { displayName: string }) => void
-  'office:move': (data: Pick<OfficeUser, 'x' | 'y'>) => void
+  'office:join': (data: { userId: string; name: string }) => void
+  'office:user:move': (data: { x: number; y: number }) => void
   'office:leave': () => void
 }
 

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -71,3 +71,8 @@ export function connectSocket(): void {
     socket.connect()
   }
 }
+
+/** Retorna a instância singleton do socket — uso em hooks e testes. */
+export function getSocket(): TypedSocket {
+  return socket
+}


### PR DESCRIPTION
## Issue
Closes #12

## O que foi feito

Hook `useOfficeState` em `src/hooks/useOfficeState.ts`:

- **Carga inicial**: `GET /api/dashboard/agents` ao montar, com cancel no unmount
- **Reducer**: 7 actions — agents loaded, status update, speech in/out, user join/leave/move
- **Socket events**: `agent:status:updated`, `bus:message`, `office:user:joined/left/moved`
- **SpeechBubble**: `speechText` por agente com auto-dismiss de 5s e cleanup de timers
- **Enriquecimento**: REST raw → `AgentOfficeData` com `zoneId`, `position {x,y}`, `color`

### Também corrigido nesta PR
- `AGENT_COLORS` em `office-layout.ts`: chaves corretas `rx-architect`, `rx-backend`, `rx-orchestrator`
- Testes de `getAgentColor` atualizados com IDs reais

## Testes

17 testes em `useOfficeState.test.ts` → **63 total**

```
✓ carga inicial (7 testes)
✓ erro na API (1 teste)
✓ eventos socket (7 testes)
✓ cleanup (1 teste — verifica off() em todos os 5 eventos)
```

## Checklist
- [x] typecheck passou
- [x] lint passou (0 erros, 0 warnings)
- [x] 63 testes passaram