### PR TITLE
feat(avatar): agentavatar e speechbubble com framer motion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,24 @@
 import { useSocket } from './hooks/useSocket'
+import { useOfficeState } from './hooks/useOfficeState'
 import { OfficeCanvas } from './components/OfficeCanvas'
+import { AgentAvatar } from './components/AgentAvatar'
 
 export function App() {
   const { status } = useSocket()
+  const { agents, users } = useOfficeState()
 
   return (
     <>
-      <OfficeCanvas connectionStatus={status} />
+      <OfficeCanvas
+        connectionStatus={status}
+        agentCount={agents.filter(a => a.status !== 'offline').length}
+        humanCount={users.length}
+      >
+        {agents.map(agent => (
+          <AgentAvatar key={agent.id} agent={agent} />
+        ))}
+      </OfficeCanvas>
+
       <div
         style={{
           position: 'fixed',
@@ -19,7 +31,7 @@ export function App() {
           userSelect: 'none',
         }}
       >
-        v0.2 — office map
+        v0.3 — agent avatars
       </div>
     </>
   )

--- a/src/components/AgentAvatar.test.tsx
+++ b/src/components/AgentAvatar.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AgentAvatar } from './AgentAvatar'
+import type { AgentOfficeData } from '../hooks/useOfficeState'
+
+// Framer Motion usa requestAnimationFrame — mockar para testes
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
+  return {
+    ...actual,
+    motion: {
+      div: ({ children, style, onClick, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
+        <div style={style} onClick={onClick} data-testid={rest['data-testid' as keyof typeof rest]}>
+          {children}
+        </div>
+      ),
+    },
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    layoutId: undefined,
+  }
+})
+
+const mockAgent: AgentOfficeData = {
+  id: 'rx-architect',
+  name: 'Architect',
+  role: 'architect',
+  status: 'idle',
+  currentTask: 'Aguardando próximo ciclo',
+  zoneId: 'coffee-corner',
+  position: { x: 30, y: 50 },
+  color: '#8b5cf6',
+  speechText: null,
+}
+
+describe('AgentAvatar', () => {
+  it('renderiza o nome do agente', () => {
+    render(<AgentAvatar agent={mockAgent} />)
+    expect(screen.getByText('Architect')).toBeTruthy()
+  })
+
+  it('renderiza o ícone correto para role architect', () => {
+    render(<AgentAvatar agent={mockAgent} />)
+    expect(screen.getByText('🤖')).toBeTruthy()
+  })
+
+  it('renderiza ícone correto para role backend', () => {
+    render(<AgentAvatar agent={{ ...mockAgent, role: 'backend' }} />)
+    expect(screen.getByText('🔬')).toBeTruthy()
+  })
+
+  it('renderiza ícone correto para role orchestrator', () => {
+    render(<AgentAvatar agent={{ ...mockAgent, role: 'orchestrator' }} />)
+    expect(screen.getByText('⚡')).toBeTruthy()
+  })
+
+  it('chama onClick ao clicar', () => {
+    const onClick = vi.fn()
+    render(<AgentAvatar agent={mockAgent} onClick={onClick} />)
+    // Clicar no container do avatar
+    const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
+    fireEvent.click(container)
+    expect(onClick).toHaveBeenCalledWith(mockAgent)
+  })
+
+  it('não renderiza SpeechBubble quando speechText é null', () => {
+    render(<AgentAvatar agent={mockAgent} />)
+    expect(screen.queryByText(/aguardando/i)).toBeNull()
+  })
+
+  it('renderiza SpeechBubble quando speechText está preenchido', () => {
+    render(<AgentAvatar agent={{ ...mockAgent, speechText: 'Analisando código' }} />)
+    expect(screen.getByText('Analisando código')).toBeTruthy()
+  })
+
+  it('badge tem aria-label com o status atual', () => {
+    render(<AgentAvatar agent={mockAgent} />)
+    expect(document.querySelector('[aria-label="status: idle"]')).toBeTruthy()
+  })
+
+  it('agente offline tem opacidade reduzida', () => {
+    render(<AgentAvatar agent={{ ...mockAgent, status: 'offline' }} />)
+    const circle = document.querySelector('[style*="opacity: 0.35"]')
+    expect(circle).toBeTruthy()
+  })
+})

--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react'
 import { motion } from 'framer-motion'
+import type { TargetAndTransition } from 'framer-motion'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
 import { SpeechBubble } from './SpeechBubble'
 
@@ -18,7 +19,7 @@ const ROLE_ICON: Record<string, string> = {
 const DEFAULT_ICON = '🤖'
 
 /** Animações Framer Motion por status */
-const STATUS_ANIMATION: Record<string, object> = {
+const STATUS_ANIMATION: Record<string, TargetAndTransition> = {
   idle: {
     y: [0, -4, 0],
     transition: { repeat: Infinity, duration: 2, ease: 'easeInOut' },

--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -1,0 +1,130 @@
+import { memo } from 'react'
+import { motion } from 'framer-motion'
+import type { AgentOfficeData } from '../hooks/useOfficeState'
+import { SpeechBubble } from './SpeechBubble'
+
+interface AgentAvatarProps {
+  agent: AgentOfficeData
+  onClick?: (agent: AgentOfficeData) => void
+}
+
+/** Ícone por role do agente */
+const ROLE_ICON: Record<string, string> = {
+  architect:    '🤖',
+  backend:      '🔬',
+  orchestrator: '⚡',
+}
+
+const DEFAULT_ICON = '🤖'
+
+/** Animações Framer Motion por status */
+const STATUS_ANIMATION: Record<string, object> = {
+  idle: {
+    y: [0, -4, 0],
+    transition: { repeat: Infinity, duration: 2, ease: 'easeInOut' },
+  },
+  working: {
+    scale: [1, 1.06, 1],
+    transition: { repeat: Infinity, duration: 0.8, ease: 'easeInOut' },
+  },
+  thinking: {
+    scale: [1, 1.04, 1],
+    transition: { repeat: Infinity, duration: 1.2, ease: 'easeInOut' },
+  },
+  blocked: {
+    x: [-2, 2, -2, 2, 0],
+    transition: { duration: 0.4 },
+  },
+  offline: {},
+}
+
+/** Cor do badge de status */
+const STATUS_BADGE_COLOR: Record<string, string> = {
+  idle:      '#6b7280',
+  working:   '#00ff41',
+  thinking:  '#f59e0b',
+  blocked:   '#ef4444',
+  offline:   '#374151',
+}
+
+export const AgentAvatar = memo(function AgentAvatar({ agent, onClick }: AgentAvatarProps) {
+  const icon = ROLE_ICON[agent.role] ?? DEFAULT_ICON
+  const animation = STATUS_ANIMATION[agent.status] ?? {}
+  const badgeColor = STATUS_BADGE_COLOR[agent.status] ?? '#6b7280'
+  const isOffline = agent.status === 'offline'
+
+  return (
+    <motion.div
+      // layoutId para transição suave ao mudar de zona
+      layoutId={`agent-${agent.id}`}
+      style={{
+        position: 'absolute',
+        left: `${agent.position.x}%`,
+        top: `${agent.position.y}%`,
+        transform: 'translate(-50%, -50%)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 4,
+        cursor: onClick ? 'pointer' : 'default',
+        userSelect: 'none',
+      }}
+      onClick={() => onClick?.(agent)}
+      whileHover={onClick ? { scale: 1.1 } : undefined}
+    >
+      {/* Balão de fala */}
+      <SpeechBubble text={agent.speechText} color={agent.color} />
+
+      {/* Avatar circular */}
+      <motion.div
+        animate={animation}
+        style={{
+          position: 'relative',
+          width: 36,
+          height: 36,
+          borderRadius: '50%',
+          background: `${agent.color}22`,
+          border: `2px solid ${agent.color}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 16,
+          opacity: isOffline ? 0.35 : 1,
+          boxShadow: isOffline ? 'none' : `0 0 8px ${agent.color}44`,
+        }}
+      >
+        {icon}
+
+        {/* Badge de status */}
+        <span
+          aria-label={`status: ${agent.status}`}
+          style={{
+            position: 'absolute',
+            bottom: -1,
+            right: -1,
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: badgeColor,
+            border: '1.5px solid #0d1117',
+            boxShadow: isOffline ? 'none' : `0 0 4px ${badgeColor}`,
+          }}
+        />
+      </motion.div>
+
+      {/* Nome do agente */}
+      <span
+        style={{
+          fontFamily: 'JetBrains Mono, monospace',
+          fontSize: 9,
+          color: isOffline ? '#374151' : '#6b7280',
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {agent.name}
+      </span>
+    </motion.div>
+  )
+})

--- a/src/components/SpeechBubble.test.tsx
+++ b/src/components/SpeechBubble.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SpeechBubble } from './SpeechBubble'
+
+describe('SpeechBubble', () => {
+  it('não renderiza nada quando text é null', () => {
+    const { container } = render(<SpeechBubble text={null} color="#8b5cf6" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renderiza o texto quando fornecido', () => {
+    render(<SpeechBubble text="Implementando feature" color="#8b5cf6" />)
+    expect(screen.getByText('Implementando feature')).toBeTruthy()
+  })
+
+  it('trunca texto maior que 40 chars com reticências', () => {
+    const longText = 'A'.repeat(50)
+    render(<SpeechBubble text={longText} color="#8b5cf6" />)
+    const el = screen.getByText(`${'A'.repeat(40)}…`)
+    expect(el).toBeTruthy()
+  })
+
+  it('não trunca texto com exatamente 40 chars', () => {
+    const text = 'A'.repeat(40)
+    render(<SpeechBubble text={text} color="#8b5cf6" />)
+    expect(screen.getByText(text)).toBeTruthy()
+  })
+
+  it('renderiza a seta apontando para baixo', () => {
+    render(<SpeechBubble text="teste" color="#8b5cf6" />)
+    expect(screen.getByTestId('speech-arrow')).toBeTruthy()
+  })
+})

--- a/src/components/SpeechBubble.tsx
+++ b/src/components/SpeechBubble.tsx
@@ -1,0 +1,75 @@
+import { memo } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+
+interface SpeechBubbleProps {
+  text: string | null
+  color: string
+}
+
+const MAX_LENGTH = 40
+
+const variants = {
+  hidden: { scale: 0, opacity: 0, y: 8 },
+  visible: {
+    scale: 1,
+    opacity: 1,
+    y: 0,
+    transition: { type: 'spring' as const, stiffness: 300, damping: 20 },
+  },
+  exit: { scale: 0, opacity: 0, transition: { duration: 0.2 } },
+}
+
+export const SpeechBubble = memo(function SpeechBubble({ text, color }: SpeechBubbleProps) {
+  const truncated = text && text.length > MAX_LENGTH ? `${text.slice(0, MAX_LENGTH)}…` : text
+
+  return (
+    <AnimatePresence>
+      {truncated && (
+        <motion.div
+          key={truncated}
+          variants={variants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 8px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            maxWidth: 180,
+            padding: '5px 8px',
+            background: 'rgba(15, 23, 42, 0.92)',
+            border: `1px solid ${color}80`,
+            borderRadius: 6,
+            fontFamily: 'JetBrains Mono, monospace',
+            fontSize: 10,
+            color: '#c9d1d9',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            lineHeight: 1.4,
+            pointerEvents: 'none',
+            zIndex: 10,
+            backdropFilter: 'blur(4px)',
+          }}
+        >
+          {truncated}
+          {/* Seta apontando para baixo */}
+          <span
+            data-testid="speech-arrow"
+            style={{
+              position: 'absolute',
+              bottom: -5,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: 0,
+              height: 0,
+              borderLeft: '5px solid transparent',
+              borderRight: '5px solid transparent',
+              borderTop: `5px solid ${color}80`,
+            }}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+})


### PR DESCRIPTION
## Issues
Closes #9
Closes #10

## O que foi feito

### AgentAvatar.tsx
- Avatar circular com cor do agente (`#8b5cf6`, `#10b981`, `#f59e0b`)
- Ícone por `role`: architect 🤖, backend 🔬, orchestrator ⚡
- Badge de status com `aria-label` e glow colorido
- Animações Framer Motion por status: float (idle), pulse (working/thinking), shake (blocked), opaco (offline)
- `layoutId` para transição suave ao mudar de zona
- `onClick` handler para futura integração com AgentDetailPanel (#16)

### SpeechBubble.tsx
- `AnimatePresence` com spring enter / fade exit
- Truncate automático a 40 chars com `…`
- Seta CSS apontando para baixo na cor do agente
- `pointerEvents: none` — não interfere com clicks no avatar

### App.tsx
- Integrado com `useOfficeState` — avatares reais dos 3 agentes
- Contagem de agentes online (`status !== 'offline'`) no HUD
- Versão bumped para v0.3 — agent avatars

## Testes
14 novos testes (9 AgentAvatar + 5 SpeechBubble) → **77 total**

## Checklist
- [x] typecheck passou
- [x] lint passou
- [x] 77 testes passaram