### PR TITLE
feat(avatar): humanavatar draggável com socket e utilitários

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,17 @@
+import { useRef } from 'react'
 import { useSocket } from './hooks/useSocket'
 import { useOfficeState } from './hooks/useOfficeState'
 import { OfficeCanvas } from './components/OfficeCanvas'
 import { AgentAvatar } from './components/AgentAvatar'
+import { HumanAvatar } from './components/HumanAvatar'
+import { socket } from './services/socket'
 
 export function App() {
   const { status } = useSocket()
   const { agents, users } = useOfficeState()
+  const canvasRef = useRef<HTMLDivElement>(null)
+
+  const mySocketId = socket.id ?? null
 
   return (
     <>
@@ -13,9 +19,18 @@ export function App() {
         connectionStatus={status}
         agentCount={agents.filter(a => a.status !== 'offline').length}
         humanCount={users.length}
+        canvasRef={canvasRef}
       >
         {agents.map(agent => (
           <AgentAvatar key={agent.id} agent={agent} />
+        ))}
+        {users.map(user => (
+          <HumanAvatar
+            key={user.socketId}
+            user={user}
+            isMe={user.socketId === mySocketId}
+            canvasRef={canvasRef}
+          />
         ))}
       </OfficeCanvas>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,14 +4,14 @@ import { useOfficeState } from './hooks/useOfficeState'
 import { OfficeCanvas } from './components/OfficeCanvas'
 import { AgentAvatar } from './components/AgentAvatar'
 import { HumanAvatar } from './components/HumanAvatar'
-import { socket } from './services/socket'
+import { getSocket } from './services/socket'
 
 export function App() {
   const { status } = useSocket()
   const { agents, users } = useOfficeState()
   const canvasRef = useRef<HTMLDivElement>(null)
 
-  const mySocketId = socket.id ?? null
+  const mySocketId = getSocket().id ?? null
 
   return (
     <>

--- a/src/components/HumanAvatar.test.tsx
+++ b/src/components/HumanAvatar.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { HumanAvatar } from './HumanAvatar'
+import type { UserOfficeData } from '../hooks/useOfficeState'
+
+vi.mock('../services/socket', () => ({
+  getSocket: () => ({ emit: vi.fn() }),
+}))
+
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
+  return {
+    ...actual,
+    motion: {
+      div: ({ children, style, drag, onDragEnd: _ode, dragConstraints: _dc, dragElastic: _de, whileDrag: _wd, animate: _an, transition: _tr, ...rest }: React.HTMLAttributes<HTMLDivElement> & { drag?: boolean; onDragEnd?: unknown; dragConstraints?: unknown; dragElastic?: unknown; whileDrag?: unknown; animate?: unknown; transition?: unknown }) => (
+        <div style={style} {...(drag !== undefined ? { 'data-drag': String(drag) } : {})} {...rest}>{children}</div>
+      ),
+    },
+  }
+})
+
+const mockUser: UserOfficeData = {
+  socketId: 'sock-1',
+  userId: 'user-abc',
+  name: 'Alice Lima',
+  x: 50,
+  y: 80,
+}
+
+const canvasRef = createRef<HTMLDivElement>()
+
+describe('HumanAvatar', () => {
+  it('exibe as iniciais do usuário', () => {
+    render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+    expect(screen.getByText('AL')).toBeTruthy()
+  })
+
+  it('exibe o nome do usuário', () => {
+    render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+    expect(screen.getByText('Alice Lima')).toBeTruthy()
+  })
+
+  it('exibe badge YOU quando isMe=true', () => {
+    render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
+    expect(screen.getByText('you')).toBeTruthy()
+  })
+
+  it('não exibe badge YOU quando isMe=false', () => {
+    render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+    expect(screen.queryByText('you')).toBeNull()
+  })
+
+  it('tem drag ativo apenas quando isMe=true', () => {
+    const { container } = render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
+    const el = container.firstChild as HTMLElement
+    expect(el.getAttribute('data-drag')).toBe('true')
+  })
+
+  it('não tem drag quando isMe=false', () => {
+    const { container } = render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+    const el = container.firstChild as HTMLElement
+    expect(el.getAttribute('data-drag')).toBeNull()
+  })
+})

--- a/src/components/HumanAvatar.tsx
+++ b/src/components/HumanAvatar.tsx
@@ -1,7 +1,7 @@
 import { memo, useRef, useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { getSocket } from '../services/socket'
-import { hashColor, initials } from '../utils/avatar'
+import { hashColor, initials, toPercent } from '../utils/avatar'
 import type { UserOfficeData } from '../hooks/useOfficeState'
 
 interface HumanAvatarProps {
@@ -9,7 +9,7 @@ interface HumanAvatarProps {
   /** Indica se este é o avatar do próprio usuário (draggable) */
   isMe: boolean
   /** Ref do elemento canvas para calcular constraints de drag */
-  canvasRef: React.RefObject<HTMLElement | null>
+  canvasRef: React.RefObject<HTMLDivElement | null>
 }
 
 const EMIT_DEBOUNCE_MS = 100
@@ -31,8 +31,8 @@ export const HumanAvatar = memo(function HumanAvatar({
       if (!canvas) return
 
       const rect = canvas.getBoundingClientRect()
-      const x = Math.min(100, Math.max(0, ((info.point.x - rect.left) / rect.width) * 100))
-      const y = Math.min(100, Math.max(0, ((info.point.y - rect.top) / rect.height) * 100))
+      const x = toPercent(info.point.x - rect.left, rect.width)
+      const y = toPercent(info.point.y - rect.top, rect.height)
 
       // Debounce para evitar flood de eventos
       const now = Date.now()

--- a/src/components/HumanAvatar.tsx
+++ b/src/components/HumanAvatar.tsx
@@ -1,0 +1,125 @@
+import { memo, useRef, useCallback } from 'react'
+import { motion } from 'framer-motion'
+import { getSocket } from '../services/socket'
+import { hashColor, initials } from '../utils/avatar'
+import type { UserOfficeData } from '../hooks/useOfficeState'
+
+interface HumanAvatarProps {
+  user: UserOfficeData
+  /** Indica se este é o avatar do próprio usuário (draggable) */
+  isMe: boolean
+  /** Ref do elemento canvas para calcular constraints de drag */
+  canvasRef: React.RefObject<HTMLElement | null>
+}
+
+const EMIT_DEBOUNCE_MS = 100
+
+export const HumanAvatar = memo(function HumanAvatar({
+  user,
+  isMe,
+  canvasRef,
+}: HumanAvatarProps) {
+  const color = hashColor(user.userId)
+  const label = initials(user.name)
+  const lastEmitAt = useRef(0)
+
+  const handleDragEnd = useCallback(
+    (_: unknown, info: { point: { x: number; y: number } }) => {
+      if (!isMe) return
+
+      const canvas = canvasRef.current
+      if (!canvas) return
+
+      const rect = canvas.getBoundingClientRect()
+      const x = Math.min(100, Math.max(0, ((info.point.x - rect.left) / rect.width) * 100))
+      const y = Math.min(100, Math.max(0, ((info.point.y - rect.top) / rect.height) * 100))
+
+      // Debounce para evitar flood de eventos
+      const now = Date.now()
+      if (now - lastEmitAt.current < EMIT_DEBOUNCE_MS) return
+      lastEmitAt.current = now
+
+      getSocket().emit('office:user:move', { x, y })
+    },
+    [isMe, canvasRef],
+  )
+
+  return (
+    <motion.div
+      style={{
+        position: 'absolute',
+        left: `${user.x}%`,
+        top: `${user.y}%`,
+        transform: 'translate(-50%, -50%)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 4,
+        cursor: isMe ? 'grab' : 'default',
+        userSelect: 'none',
+        zIndex: isMe ? 20 : 10,
+      }}
+      // Animar suavemente para nova posição (outros usuários)
+      animate={{ left: `${user.x}%`, top: `${user.y}%` }}
+      transition={{ type: 'spring', stiffness: 200, damping: 25 }}
+      drag={isMe || undefined}
+      dragConstraints={canvasRef}
+      dragElastic={0.05}
+      whileDrag={{ scale: 1.12, cursor: 'grabbing', zIndex: 1000 }}
+      onDragEnd={handleDragEnd}
+    >
+      {/* Avatar circular */}
+      <div
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: '50%',
+          background: `${color}33`,
+          border: `2px solid ${color}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'JetBrains Mono, monospace',
+          fontSize: 11,
+          fontWeight: 700,
+          color,
+          boxShadow: `0 0 6px ${color}55`,
+        }}
+      >
+        {label}
+      </div>
+
+      {/* Badge YOU + nome */}
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
+        {isMe && (
+          <span
+            style={{
+              fontSize: 8,
+              fontFamily: 'JetBrains Mono, monospace',
+              color,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+            }}
+          >
+            you
+          </span>
+        )}
+        <span
+          style={{
+            fontSize: 9,
+            fontFamily: 'JetBrains Mono, monospace',
+            color: '#6b7280',
+            letterSpacing: '0.04em',
+            whiteSpace: 'nowrap',
+            maxWidth: 64,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+          title={user.name}
+        >
+          {user.name}
+        </span>
+      </div>
+    </motion.div>
+  )
+})

--- a/src/components/OfficeCanvas.tsx
+++ b/src/components/OfficeCanvas.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import { OFFICE_ZONES } from '../data/office-layout'
 import { OfficeRoom } from './OfficeRoom'
 import { OfficeHUD } from './OfficeHUD'
@@ -9,6 +9,8 @@ interface OfficeCanvasProps {
   connectionStatus: ConnectionStatus
   agentCount?: number
   humanCount?: number
+  /** Ref para o elemento raiz — usado como dragConstraints pelo HumanAvatar */
+  canvasRef?: RefObject<HTMLDivElement | null>
 }
 
 const GRID_STYLE: React.CSSProperties = {
@@ -27,9 +29,11 @@ export function OfficeCanvas({
   connectionStatus,
   agentCount = 0,
   humanCount = 0,
+  canvasRef,
 }: OfficeCanvasProps) {
   return (
     <div
+      ref={canvasRef}
       style={{
         position: 'relative',
         width: '100%',

--- a/src/utils/avatar.test.ts
+++ b/src/utils/avatar.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { hashColor, initials, toPercent } from './avatar'
+
+describe('hashColor', () => {
+  it('retorna uma string de cor hex', () => {
+    expect(hashColor('user-1')).toMatch(/^#[0-9a-f]{6}$/)
+  })
+
+  it('retorna a mesma cor para o mesmo userId', () => {
+    expect(hashColor('abc')).toBe(hashColor('abc'))
+  })
+
+  it('retorna cores distintas para userIds diferentes', () => {
+    const colors = new Set(['user-1','user-2','user-3','user-4'].map(hashColor))
+    expect(colors.size).toBeGreaterThan(1)
+  })
+})
+
+describe('initials', () => {
+  it('retorna 2 letras maiúsculas de nome completo', () => {
+    expect(initials('João Silva')).toBe('JS')
+  })
+
+  it('retorna 2 primeiras letras para nome único', () => {
+    expect(initials('Alice')).toBe('AL')
+  })
+
+  it('usa primeira e última palavra para nomes compostos', () => {
+    expect(initials('Maria da Silva')).toBe('MS')
+  })
+
+  it('lida com espaços extras', () => {
+    expect(initials('  Ana  Lima  ')).toBe('AL')
+  })
+})
+
+describe('toPercent', () => {
+  it('converte px para porcentagem', () => {
+    expect(toPercent(250, 1000)).toBe(25)
+  })
+
+  it('clampeia no mínimo 0', () => {
+    expect(toPercent(-50, 1000)).toBe(0)
+  })
+
+  it('clampeia no máximo 100', () => {
+    expect(toPercent(1200, 1000)).toBe(100)
+  })
+
+  it('retorna 50 para o centro', () => {
+    expect(toPercent(500, 1000)).toBe(50)
+  })
+})

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,38 @@
+/**
+ * Paleta de cores para avatares humanos.
+ * Gerada via hash do userId — distribuição uniforme.
+ */
+const AVATAR_PALETTE = [
+  '#3b82f6', // blue
+  '#ec4899', // pink
+  '#14b8a6', // teal
+  '#f97316', // orange
+  '#a855f7', // purple
+  '#84cc16', // lime
+  '#06b6d4', // cyan
+  '#f43f5e', // rose
+]
+
+/** Retorna uma cor estável para um dado userId. */
+export function hashColor(userId: string): string {
+  let hash = 0
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0
+  }
+  return AVATAR_PALETTE[hash % AVATAR_PALETTE.length]
+}
+
+/** Retorna as iniciais (até 2 letras) de um nome. */
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+/**
+ * Converte uma posição em pixels (relativa ao container) para percentual (0–100).
+ * Clampeia para garantir que o avatar fique dentro dos limites.
+ */
+export function toPercent(px: number, total: number): number {
+  return Math.min(100, Math.max(0, (px / total) * 100))
+}


### PR DESCRIPTION
## Issues
Closes #13 — HumanAvatar.tsx draggable com Framer Motion
Closes #14 — Utilitários de avatar (hashColor, initials, toPercent)

## O que foi feito

### `src/components/HumanAvatar.tsx`
- Avatar draggável via `motion.div` do Framer Motion
- Emite `office:user:move` via socket com debounce 100ms
- Badge `you` exibida apenas para `isMe=true`
- Cor gerada deterministicamente por `hashColor(userId)`
- Recebe `canvasRef` para constraints do drag

### `src/utils/avatar.ts`
- `hashColor(userId)` — cor HSL determinística por userId
- `initials(name)` — duas iniciais do nome
- `toPercent(px, total)` — converte px para % do container

### `src/components/OfficeCanvas.tsx`
- Prop `canvasRef?: RefObject<HTMLDivElement | null>` para constraints do drag

### `src/App.tsx`
- `HumanAvatar` integrado com `canvasRef` e `socket.id` para `isMe`

## Testes
- 6 testes em `HumanAvatar.test.tsx`
- 11 testes em `avatar.test.ts`
- Total: **94 testes passando** (antes: 77)

## Checklist
- [x] Testes passando (94/94)
- [x] TypeScript sem erros
- [x] ESLint sem warnings