### PR TITLE
feat(presence): lista de usuarios online com animatepresence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useOfficeState } from './hooks/useOfficeState'
 import { OfficeCanvas } from './components/OfficeCanvas'
 import { AgentAvatar } from './components/AgentAvatar'
 import { HumanAvatar } from './components/HumanAvatar'
+import { OnlineUsersList } from './components/OnlineUsersList'
 import { getSocket } from './services/socket'
 
 export function App() {
@@ -34,6 +35,8 @@ export function App() {
         ))}
       </OfficeCanvas>
 
+      <OnlineUsersList users={users} mySocketId={mySocketId} />
+
       <div
         style={{
           position: 'fixed',
@@ -46,7 +49,7 @@ export function App() {
           userSelect: 'none',
         }}
       >
-        v0.3 — agent avatars
+        v0.4 — human presence
       </div>
     </>
   )

--- a/src/components/OnlineUsersList.test.tsx
+++ b/src/components/OnlineUsersList.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OnlineUsersList } from './OnlineUsersList'
+import type { UserOfficeData } from '../hooks/useOfficeState'
+
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
+  return {
+    ...actual,
+    motion: {
+      div: ({
+        children,
+        style,
+        layout: _l,
+        variants: _v,
+        initial: _i,
+        animate: _a,
+        exit: _e,
+        transition: _t,
+        ...rest
+      }: React.HTMLAttributes<HTMLDivElement> & {
+        layout?: unknown
+        variants?: unknown
+        initial?: unknown
+        animate?: unknown
+        exit?: unknown
+        transition?: unknown
+      }) => (
+        <div style={style} {...rest}>
+          {children}
+        </div>
+      ),
+    },
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  }
+})
+
+const mockUsers: UserOfficeData[] = [
+  { socketId: 'sock-1', userId: 'user-abc', name: 'Alice Lima', x: 50, y: 80 },
+  { socketId: 'sock-2', userId: 'user-def', name: 'Bob Silva', x: 30, y: 40 },
+]
+
+describe('OnlineUsersList', () => {
+  it('não renderiza quando lista está vazia', () => {
+    const { container } = render(
+      <OnlineUsersList users={[]} mySocketId={null} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('exibe cabeçalho com contagem de usuários', () => {
+    render(<OnlineUsersList users={mockUsers} mySocketId={null} />)
+    expect(screen.getByText(/online · 2/i)).toBeTruthy()
+  })
+
+  it('exibe nome de todos os usuários', () => {
+    render(<OnlineUsersList users={mockUsers} mySocketId={null} />)
+    expect(screen.getByText('Alice Lima')).toBeTruthy()
+    expect(screen.getByText('Bob Silva')).toBeTruthy()
+  })
+
+  it('exibe badge you apenas para o próprio usuário', () => {
+    render(<OnlineUsersList users={mockUsers} mySocketId="sock-1" />)
+    expect(screen.getByText('you')).toBeTruthy()
+  })
+
+  it('não exibe badge you quando mySocketId não corresponde', () => {
+    render(<OnlineUsersList users={mockUsers} mySocketId="sock-999" />)
+    expect(screen.queryByText('you')).toBeNull()
+  })
+
+  it('tem role list e aria-label para acessibilidade', () => {
+    render(<OnlineUsersList users={mockUsers} mySocketId={null} />)
+    const list = screen.getByRole('list', { name: /usuários online/i })
+    expect(list).toBeTruthy()
+  })
+
+  it('exibe as iniciais de cada usuário', () => {
+    render(<OnlineUsersList users={mockUsers} mySocketId={null} />)
+    expect(screen.getByText('AL')).toBeTruthy()
+    expect(screen.getByText('BS')).toBeTruthy()
+  })
+
+  it('exibe contagem correta com 1 usuário', () => {
+    render(<OnlineUsersList users={[mockUsers[0]]} mySocketId={null} />)
+    expect(screen.getByText(/online · 1/i)).toBeTruthy()
+  })
+})

--- a/src/components/OnlineUsersList.tsx
+++ b/src/components/OnlineUsersList.tsx
@@ -1,0 +1,134 @@
+import { memo } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import type { UserOfficeData } from '../hooks/useOfficeState'
+import { hashColor, initials } from '../utils/avatar'
+
+interface OnlineUsersListProps {
+  users: UserOfficeData[]
+  mySocketId: string | null
+}
+
+const ITEM_VARIANTS = {
+  hidden: { opacity: 0, x: -12 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.2 } },
+  exit: { opacity: 0, x: -12, transition: { duration: 0.15 } },
+}
+
+const UserRow = memo(function UserRow({
+  user,
+  isMe,
+}: {
+  user: UserOfficeData
+  isMe: boolean
+}) {
+  const color = hashColor(user.userId)
+  const label = initials(user.name)
+
+  return (
+    <motion.div
+      layout
+      variants={ITEM_VARIANTS}
+      initial="hidden"
+      animate="visible"
+      exit="exit"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 7,
+        padding: '3px 0',
+      }}
+    >
+      {/* Avatar circular mini */}
+      <div
+        aria-hidden="true"
+        style={{
+          width: 20,
+          height: 20,
+          borderRadius: '50%',
+          background: `${color}22`,
+          border: `1.5px solid ${color}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 8,
+          fontWeight: 700,
+          color,
+          flexShrink: 0,
+        }}
+      >
+        {label}
+      </div>
+
+      {/* Nome */}
+      <span
+        style={{
+          fontSize: 10,
+          color: isMe ? color : '#9ca3af',
+          fontWeight: isMe ? 700 : 400,
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          maxWidth: 90,
+        }}
+        title={user.name}
+      >
+        {user.name}
+        {isMe && (
+          <span style={{ color, opacity: 0.7, marginLeft: 4, fontSize: 8 }}>you</span>
+        )}
+      </span>
+    </motion.div>
+  )
+})
+
+export const OnlineUsersList = memo(function OnlineUsersList({
+  users,
+  mySocketId,
+}: OnlineUsersListProps) {
+  if (users.length === 0) return null
+
+  return (
+    <div
+      role="list"
+      aria-label="usuários online"
+      style={{
+        position: 'fixed',
+        top: 16,
+        right: 16,
+        padding: '8px 10px',
+        background: '#0d1117cc',
+        border: '1px solid #1f2937',
+        borderRadius: 6,
+        backdropFilter: 'blur(8px)',
+        fontFamily: 'JetBrains Mono, monospace',
+        minWidth: 130,
+        maxWidth: 160,
+        zIndex: 50,
+      }}
+    >
+      {/* Cabeçalho */}
+      <div
+        style={{
+          fontSize: 9,
+          color: '#4b5563',
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          marginBottom: 6,
+          borderBottom: '1px solid #1f2937',
+          paddingBottom: 4,
+        }}
+      >
+        online · {users.length}
+      </div>
+
+      {/* Lista com AnimatePresence para animações de join/leave */}
+      <AnimatePresence initial={false}>
+        {users.map(user => (
+          <div key={user.socketId} role="listitem">
+            <UserRow user={user} isMe={user.socketId === mySocketId} />
+          </div>
+        ))}
+      </AnimatePresence>
+    </div>
+  )
+})

--- a/src/components/OnlineUsersList.tsx
+++ b/src/components/OnlineUsersList.tsx
@@ -21,8 +21,8 @@ const UserRow = memo(function UserRow({
   user: UserOfficeData
   isMe: boolean
 }) {
-  const color = hashColor(user.userId)
-  const label = initials(user.name)
+  const color = user.userId ? hashColor(user.userId) : '#6b7280'
+  const label = user.name ? initials(user.name) : '?'
 
   return (
     <motion.div


### PR DESCRIPTION
## Issues
Closes #15 — feat(presence): lista de usuarios online com join/leave tracking

## O que foi feito

### `src/components/OnlineUsersList.tsx`
- Painel overlay `position: fixed` top-right com lista de usuários online
- `AnimatePresence` para animações fluidas de join (slide + fade in) e leave (slide + fade out)
- Badge `you` para o usuário local identificado via `mySocketId`
- Iniciais e cor via `hashColor(userId)` — consistente com `HumanAvatar`
- Cabeçalho `online · N` com contagem atualizada em tempo real
- Acessível: `role="list"` + `aria-label="usuários online"` + `role="listitem"`
- `memo` + `layout` animation no `motion.div` para performance

### `src/App.tsx`
- Integrado `OnlineUsersList` com `users` do `useOfficeState` e `mySocketId`
- Versão atualizada para `v0.4 — human presence`

## Testes
- 8 testes em `OnlineUsersList.test.tsx`
- Total: **102 testes passando** (antes: 94)

## Checklist
- [x] Testes passando (102/102)
- [x] TypeScript sem erros
- [x] ESLint sem warnings