### PR TITLE
feat(hacker): hacker mode theme com atalho ctrl+shift+h

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default [
         EventTarget: 'readonly',
         AbortController: 'readonly',
         KeyboardEvent: 'readonly',
+        localStorage: 'readonly',
         React: 'readonly',
         JSX: 'readonly',
         import: 'readonly',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,9 @@ import { useRef, useState, useCallback } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import { useSocket } from './hooks/useSocket'
 import { useOfficeState } from './hooks/useOfficeState'
+import { useHackerMode } from './hooks/useHackerMode'
 import type { AgentOfficeData } from './hooks/useOfficeState'
+import { ThemeProvider } from './contexts/ThemeContext'
 import { OfficeCanvas } from './components/OfficeCanvas'
 import { AgentAvatar } from './components/AgentAvatar'
 import { HumanAvatar } from './components/HumanAvatar'
@@ -13,6 +15,7 @@ import { getSocket } from './services/socket'
 export function App() {
   const { status } = useSocket()
   const { agents, users } = useOfficeState()
+  const { isHackerMode, toggle: toggleHackerMode } = useHackerMode()
   const canvasRef = useRef<HTMLDivElement>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
 
@@ -29,12 +32,13 @@ export function App() {
   }, [])
 
   return (
-    <>
+    <ThemeProvider isHackerMode={isHackerMode}>
       <OfficeCanvas
         connectionStatus={status}
         agentCount={agents.filter(a => a.status !== 'offline').length}
         humanCount={users.length}
         canvasRef={canvasRef}
+        onToggleHackerMode={toggleHackerMode}
       >
         {agents.map(agent => (
           <AgentAvatar
@@ -73,13 +77,14 @@ export function App() {
           left: 16,
           fontFamily: 'JetBrains Mono, monospace',
           fontSize: 10,
-          color: '#374151',
+          color: isHackerMode ? '#00ff41' : '#374151',
           pointerEvents: 'none',
           userSelect: 'none',
+          transition: 'color 0.4s ease',
         }}
       >
-        v0.5 — interactions
+        {isHackerMode ? '> HACKER MODE ACTIVE' : 'v0.5 — interactions'}
       </div>
-    </>
+    </ThemeProvider>
   )
 }

--- a/src/components/OfficeCanvas.tsx
+++ b/src/components/OfficeCanvas.tsx
@@ -3,6 +3,7 @@ import { OFFICE_ZONES } from '../data/office-layout'
 import { OfficeRoom } from './OfficeRoom'
 import { OfficeHUD } from './OfficeHUD'
 import type { ConnectionStatus } from '../hooks/useSocket'
+import { useTheme } from '../contexts/ThemeContext'
 
 interface OfficeCanvasProps {
   children?: ReactNode
@@ -11,17 +12,7 @@ interface OfficeCanvasProps {
   humanCount?: number
   /** Ref para o elemento raiz — usado como dragConstraints pelo HumanAvatar */
   canvasRef?: RefObject<HTMLDivElement | null>
-}
-
-const GRID_STYLE: React.CSSProperties = {
-  position: 'absolute',
-  inset: 0,
-  backgroundImage: `
-    radial-gradient(circle, #1f2937 1px, transparent 1px)
-  `,
-  backgroundSize: '28px 28px',
-  opacity: 0.4,
-  pointerEvents: 'none',
+  onToggleHackerMode?: () => void
 }
 
 export function OfficeCanvas({
@@ -30,7 +21,22 @@ export function OfficeCanvas({
   agentCount = 0,
   humanCount = 0,
   canvasRef,
+  onToggleHackerMode,
 }: OfficeCanvasProps) {
+  const theme = useTheme()
+
+  const gridStyle: React.CSSProperties = {
+    position: 'absolute',
+    inset: 0,
+    backgroundImage: theme.isHackerMode
+      ? `repeating-linear-gradient(0deg, ${theme.grid}0d 0px, transparent 1px, transparent 27px, ${theme.grid}0d 28px),
+         repeating-linear-gradient(90deg, ${theme.grid}0d 0px, transparent 1px, transparent 27px, ${theme.grid}0d 28px)`
+      : `radial-gradient(circle, #1f2937 1px, transparent 1px)`,
+    backgroundSize: '28px 28px',
+    opacity: theme.isHackerMode ? 1 : 0.4,
+    pointerEvents: 'none',
+  }
+
   return (
     <div
       ref={canvasRef}
@@ -38,13 +44,14 @@ export function OfficeCanvas({
         position: 'relative',
         width: '100%',
         height: '100vh',
-        background: '#0d1117',
+        background: theme.bg,
         overflow: 'hidden',
         fontFamily: 'JetBrains Mono, monospace',
+        transition: 'background 0.4s ease',
       }}
     >
-      {/* Grid decorativo de fundo */}
-      <div style={GRID_STYLE} />
+      {/* Grid decorativo */}
+      <div style={gridStyle} />
 
       {/* Zonas do escritório */}
       {OFFICE_ZONES.map(zone => (
@@ -59,6 +66,7 @@ export function OfficeCanvas({
         connectionStatus={connectionStatus}
         agentCount={agentCount}
         humanCount={humanCount}
+        onToggleHackerMode={onToggleHackerMode}
       />
     </div>
   )

--- a/src/components/OfficeCanvas.tsx
+++ b/src/components/OfficeCanvas.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, RefObject } from 'react'
+import { useMemo, type ReactNode, type RefObject } from 'react'
 import { OFFICE_ZONES } from '../data/office-layout'
 import { OfficeRoom } from './OfficeRoom'
 import { OfficeHUD } from './OfficeHUD'
@@ -25,7 +25,7 @@ export function OfficeCanvas({
 }: OfficeCanvasProps) {
   const theme = useTheme()
 
-  const gridStyle: React.CSSProperties = {
+  const gridStyle = useMemo<React.CSSProperties>(() => ({
     position: 'absolute',
     inset: 0,
     backgroundImage: theme.isHackerMode
@@ -35,7 +35,7 @@ export function OfficeCanvas({
     backgroundSize: '28px 28px',
     opacity: theme.isHackerMode ? 1 : 0.4,
     pointerEvents: 'none',
-  }
+  }), [theme.isHackerMode, theme.grid])
 
   return (
     <div

--- a/src/components/OfficeHUD.tsx
+++ b/src/components/OfficeHUD.tsx
@@ -1,18 +1,22 @@
 import { memo } from 'react'
 import type { ConnectionStatus } from '../hooks/useSocket'
 import { STATUS_COLOR, STATUS_LABEL } from '../constants/status'
+import { useTheme } from '../contexts/ThemeContext'
 
 interface OfficeHUDProps {
   connectionStatus: ConnectionStatus
   agentCount?: number
   humanCount?: number
+  onToggleHackerMode?: () => void
 }
 
 export const OfficeHUD = memo(function OfficeHUD({
   connectionStatus,
   agentCount = 0,
   humanCount = 0,
+  onToggleHackerMode,
 }: OfficeHUDProps) {
+  const theme = useTheme()
   const color = STATUS_COLOR[connectionStatus]
   const label = STATUS_LABEL[connectionStatus]
 
@@ -26,13 +30,15 @@ export const OfficeHUD = memo(function OfficeHUD({
         alignItems: 'center',
         gap: 12,
         padding: '6px 12px',
-        background: '#0d1117cc',
-        border: '1px solid #1f2937',
+        background: theme.isHackerMode ? '#000000cc' : '#0d1117cc',
+        border: `1px solid ${theme.hudBorder}`,
         borderRadius: 6,
         backdropFilter: 'blur(8px)',
         fontFamily: 'JetBrains Mono, monospace',
         fontSize: 11,
-        color: '#6b7280',
+        color: theme.label,
+        transition: 'border-color 0.4s ease, color 0.4s ease',
+        boxShadow: theme.isHackerMode ? `0 0 8px ${theme.hudBorder}44` : 'none',
       }}
     >
       {/* Status conexão */}
@@ -44,22 +50,46 @@ export const OfficeHUD = memo(function OfficeHUD({
             width: 6,
             height: 6,
             borderRadius: '50%',
-            background: color,
-            boxShadow: `0 0 4px ${color}`,
+            background: theme.isHackerMode ? theme.label : color,
+            boxShadow: `0 0 4px ${theme.isHackerMode ? theme.label : color}`,
           }}
         />
-        <span style={{ color }}>{label}</span>
+        <span style={{ color: theme.isHackerMode ? theme.label : color }}>{label}</span>
       </div>
 
-      <span style={{ color: '#374151' }}>│</span>
+      <span style={{ color: theme.isHackerMode ? `${theme.label}50` : '#374151' }}>│</span>
 
       {/* Agentes online */}
       <span>{agentCount} agent{agentCount !== 1 ? 's' : ''}</span>
 
       {humanCount > 0 && (
         <>
-          <span style={{ color: '#374151' }}>│</span>
+          <span style={{ color: theme.isHackerMode ? `${theme.label}50` : '#374151' }}>│</span>
           <span>{humanCount} human{humanCount !== 1 ? 's' : ''}</span>
+        </>
+      )}
+
+      {/* Botão Hacker Mode */}
+      {onToggleHackerMode && (
+        <>
+          <span style={{ color: theme.isHackerMode ? `${theme.label}50` : '#374151' }}>│</span>
+          <button
+            onClick={onToggleHackerMode}
+            aria-label={theme.isHackerMode ? 'desativar hacker mode' : 'ativar hacker mode'}
+            title="Ctrl+Shift+H"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: theme.isHackerMode ? theme.label : '#4b5563',
+              cursor: 'pointer',
+              fontFamily: 'JetBrains Mono, monospace',
+              fontSize: 9,
+              padding: 0,
+              letterSpacing: '0.05em',
+            }}
+          >
+            {theme.isHackerMode ? '[H]' : 'H'}
+          </button>
         </>
       )}
     </div>

--- a/src/components/OfficeRoom.tsx
+++ b/src/components/OfficeRoom.tsx
@@ -1,11 +1,14 @@
 import { memo } from 'react'
 import type { Zone } from '../data/office-layout'
+import { useTheme } from '../contexts/ThemeContext'
 
 interface OfficeRoomProps {
   zone: Zone
 }
 
 export const OfficeRoom = memo(function OfficeRoom({ zone }: OfficeRoomProps) {
+  const theme = useTheme()
+
   return (
     <div
       data-zone-id={zone.id}
@@ -15,10 +18,12 @@ export const OfficeRoom = memo(function OfficeRoom({ zone }: OfficeRoomProps) {
         top: `${zone.y}%`,
         width: `${zone.width}%`,
         height: `${zone.height}%`,
-        background: zone.color,
-        border: '1px solid #1f2937',
+        background: theme.isHackerMode ? theme.zoneBg : zone.color,
+        border: `1px solid ${theme.zoneBorder}`,
         borderRadius: 8,
         overflow: 'hidden',
+        transition: 'background 0.4s ease, border-color 0.4s ease',
+        boxShadow: theme.isHackerMode ? `0 0 8px ${theme.zoneBorder}44` : 'none',
       }}
     >
       {/* Header da zona */}
@@ -28,7 +33,7 @@ export const OfficeRoom = memo(function OfficeRoom({ zone }: OfficeRoomProps) {
           alignItems: 'center',
           gap: 6,
           padding: '6px 10px',
-          borderBottom: '1px solid #1f293780',
+          borderBottom: `1px solid ${theme.zoneBorder}50`,
         }}
       >
         <span style={{ fontSize: 12 }}>{zone.icon}</span>
@@ -36,9 +41,10 @@ export const OfficeRoom = memo(function OfficeRoom({ zone }: OfficeRoomProps) {
           style={{
             fontSize: 10,
             fontFamily: 'JetBrains Mono, monospace',
-            color: '#6b7280',
+            color: theme.label,
             letterSpacing: '0.05em',
             textTransform: 'uppercase',
+            transition: 'color 0.4s ease',
           }}
         >
           {zone.label}

--- a/src/contexts/ThemeContext.test.tsx
+++ b/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider, useTheme, DEFAULT_THEME, HACKER_THEME } from './ThemeContext'
+
+function ThemeConsumer() {
+  const theme = useTheme()
+  return (
+    <div>
+      <span data-testid="bg">{theme.bg}</span>
+      <span data-testid="hacker">{String(theme.isHackerMode)}</span>
+      <span data-testid="label">{theme.label}</span>
+    </div>
+  )
+}
+
+describe('ThemeContext', () => {
+  it('provê tema padrão quando isHackerMode=false', () => {
+    render(
+      <ThemeProvider isHackerMode={false}>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    )
+    expect(screen.getByTestId('bg').textContent).toBe(DEFAULT_THEME.bg)
+    expect(screen.getByTestId('hacker').textContent).toBe('false')
+  })
+
+  it('provê tema hacker quando isHackerMode=true', () => {
+    render(
+      <ThemeProvider isHackerMode={true}>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    )
+    expect(screen.getByTestId('bg').textContent).toBe(HACKER_THEME.bg)
+    expect(screen.getByTestId('hacker').textContent).toBe('true')
+    expect(screen.getByTestId('label').textContent).toBe('#00ff41')
+  })
+
+  it('useTheme retorna DEFAULT_THEME fora do provider', () => {
+    render(<ThemeConsumer />)
+    expect(screen.getByTestId('bg').textContent).toBe(DEFAULT_THEME.bg)
+  })
+})

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,54 @@
+import { createContext, useContext, type ReactNode } from 'react'
+
+export interface Theme {
+  isHackerMode: boolean
+  /** Fundo principal */
+  bg: string
+  /** Cor de grade/decoração */
+  grid: string
+  /** Cor de borda de zonas */
+  zoneBorder: string
+  /** Fundo de zona */
+  zoneBg: string
+  /** Cor primária de labels/texto */
+  label: string
+  /** Cor do HUD */
+  hudBorder: string
+}
+
+export const DEFAULT_THEME: Theme = {
+  isHackerMode: false,
+  bg: '#0d1117',
+  grid: '#1f2937',
+  zoneBorder: '#1f2937',
+  zoneBg: '#111827',
+  label: '#6b7280',
+  hudBorder: '#1f2937',
+}
+
+export const HACKER_THEME: Theme = {
+  isHackerMode: true,
+  bg: '#000000',
+  grid: '#00ff41',
+  zoneBorder: '#00ff41',
+  zoneBg: '#001100',
+  label: '#00ff41',
+  hudBorder: '#00ff41',
+}
+
+export const ThemeContext = createContext<Theme>(DEFAULT_THEME)
+
+export function useTheme(): Theme {
+  return useContext(ThemeContext)
+}
+
+export function ThemeProvider({
+  isHackerMode,
+  children,
+}: {
+  isHackerMode: boolean
+  children: ReactNode
+}) {
+  const theme = isHackerMode ? HACKER_THEME : DEFAULT_THEME
+  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from 'react'
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
 
 export interface Theme {
   isHackerMode: boolean
@@ -49,6 +49,6 @@ export function ThemeProvider({
   isHackerMode: boolean
   children: ReactNode
 }) {
-  const theme = isHackerMode ? HACKER_THEME : DEFAULT_THEME
+  const theme = useMemo(() => (isHackerMode ? HACKER_THEME : DEFAULT_THEME), [isHackerMode])
   return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
 }

--- a/src/hooks/useHackerMode.test.ts
+++ b/src/hooks/useHackerMode.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useHackerMode } from './useHackerMode'
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value }),
+    clear: () => { store = {} },
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+describe('useHackerMode', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.clearAllMocks()
+  })
+
+  it('inicia com isHackerMode=false por padrão', () => {
+    const { result } = renderHook(() => useHackerMode())
+    expect(result.current.isHackerMode).toBe(false)
+  })
+
+  it('toggle ativa o hacker mode', () => {
+    const { result } = renderHook(() => useHackerMode())
+    act(() => { result.current.toggle() })
+    expect(result.current.isHackerMode).toBe(true)
+  })
+
+  it('toggle duas vezes volta para false', () => {
+    const { result } = renderHook(() => useHackerMode())
+    act(() => { result.current.toggle() })
+    act(() => { result.current.toggle() })
+    expect(result.current.isHackerMode).toBe(false)
+  })
+
+  it('persiste estado no localStorage ao ativar', () => {
+    const { result } = renderHook(() => useHackerMode())
+    act(() => { result.current.toggle() })
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('mago-office:hacker-mode', 'true')
+  })
+
+  it('persiste estado no localStorage ao desativar', () => {
+    const { result } = renderHook(() => useHackerMode())
+    act(() => { result.current.toggle() })
+    act(() => { result.current.toggle() })
+    expect(localStorageMock.setItem).toHaveBeenLastCalledWith('mago-office:hacker-mode', 'false')
+  })
+
+  it('lê estado inicial do localStorage', () => {
+    localStorageMock.getItem.mockReturnValueOnce('true')
+    const { result } = renderHook(() => useHackerMode())
+    expect(result.current.isHackerMode).toBe(true)
+  })
+
+  it('ativa com Ctrl+Shift+H', () => {
+    const { result } = renderHook(() => useHackerMode())
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'H', ctrlKey: true, shiftKey: true }))
+    })
+    expect(result.current.isHackerMode).toBe(true)
+  })
+
+  it('desativa com Ctrl+Shift+H quando já ativo', () => {
+    const { result } = renderHook(() => useHackerMode())
+    act(() => { result.current.toggle() })
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'H', ctrlKey: true, shiftKey: true }))
+    })
+    expect(result.current.isHackerMode).toBe(false)
+  })
+})

--- a/src/hooks/useHackerMode.ts
+++ b/src/hooks/useHackerMode.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect, useCallback } from 'react'
+
+const STORAGE_KEY = 'mago-office:hacker-mode'
+const TOGGLE_KEY = 'h'
+
+export interface HackerModeState {
+  isHackerMode: boolean
+  toggle: () => void
+}
+
+/**
+ * Persiste e controla o Hacker Mode.
+ * Atalho: Ctrl+Shift+H
+ */
+export function useHackerMode(): HackerModeState {
+  const [isHackerMode, setIsHackerMode] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true'
+    } catch {
+      return false
+    }
+  })
+
+  const toggle = useCallback(() => {
+    setIsHackerMode(prev => {
+      const next = !prev
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next))
+      } catch {
+        // storage indisponível — ignora
+      }
+      return next
+    })
+  }, [])
+
+  useEffect(() => {
+    function onKey(e: globalThis.KeyboardEvent) {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === TOGGLE_KEY) {
+        e.preventDefault()
+        toggle()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [toggle])
+
+  return { isHackerMode, toggle }
+}


### PR DESCRIPTION
## Issues
Closes #21 — feat(ui): hacker mode theme para office view

## O que foi feito

### `src/hooks/useHackerMode.ts`
- Toggle com persistência em `localStorage`
- Atalho de teclado: `Ctrl+Shift+H`
- Lê estado inicial do storage (persiste entre sessões)

### `src/contexts/ThemeContext.tsx`
- `DEFAULT_THEME` e `HACKER_THEME` com cores completas
- `ThemeProvider` envolve o app com o tema ativo
- `useTheme()` hook consumido pelos componentes
- Transições suaves (0.4s ease) em todos os elementos

### Componentes atualizados
- **OfficeCanvas**: grid de linhas verdes (repeat-linear-gradient) no hacker mode, bg `#000000`
- **OfficeRoom**: borda verde `#00ff41`, fundo `#001100`, glow via box-shadow
- **OfficeHUD**: cores verdes, botão `[H]`/`H` para toggle visível no HUD, title="Ctrl+Shift+H"
- **App.tsx**: `ThemeProvider` wrapping todo o app, label alterna entre `v0.5` e `> HACKER MODE ACTIVE`

## Testes
- 8 testes em `useHackerMode.test.ts`
- 3 testes em `ThemeContext.test.tsx`
- Total: **126 testes passando** (antes: 115)

## Checklist
- [x] Testes passando (126/126)
- [x] TypeScript sem erros
- [x] ESLint sem warnings