### PR TITLE
feat(ui): tooltip no agentavatar e atributos aria no humanavatar

### DIFF
--- a/src/components/AgentAvatar.test.tsx
+++ b/src/components/AgentAvatar.test.tsx
@@ -1,18 +1,18 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { AgentAvatar } from './AgentAvatar'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
+import { ThemeProvider } from '../contexts/ThemeContext'
 
-// Framer Motion usa requestAnimationFrame — mockar para testes
+type MotionDivProps = React.HTMLAttributes<HTMLDivElement> & Record<string, unknown>
+
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
   return {
     ...actual,
     motion: {
-      div: ({ children, style, onClick, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
-        <div style={style} onClick={onClick} data-testid={rest['data-testid' as keyof typeof rest]}>
-          {children}
-        </div>
+      div: ({ children, animate: _a, whileHover: _wh, transition: _t, layoutId: _lid, variants: _v, initial: _i, exit: _e, layout: _l, ...rest }: MotionDivProps) => (
+        <div {...rest}>{children}</div>
       ),
     },
     AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -32,54 +32,84 @@ const mockAgent: AgentOfficeData = {
   speechText: null,
 }
 
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider isHackerMode={false}>{children}</ThemeProvider>
+}
+
 describe('AgentAvatar', () => {
   it('renderiza o nome do agente', () => {
-    render(<AgentAvatar agent={mockAgent} />)
+    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
     expect(screen.getByText('Architect')).toBeTruthy()
   })
 
   it('renderiza o ícone correto para role architect', () => {
-    render(<AgentAvatar agent={mockAgent} />)
+    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
     expect(screen.getByText('🤖')).toBeTruthy()
   })
 
   it('renderiza ícone correto para role backend', () => {
-    render(<AgentAvatar agent={{ ...mockAgent, role: 'backend' }} />)
+    render(<AgentAvatar agent={{ ...mockAgent, role: 'backend' }} />, { wrapper: Wrapper })
     expect(screen.getByText('🔬')).toBeTruthy()
   })
 
   it('renderiza ícone correto para role orchestrator', () => {
-    render(<AgentAvatar agent={{ ...mockAgent, role: 'orchestrator' }} />)
+    render(<AgentAvatar agent={{ ...mockAgent, role: 'orchestrator' }} />, { wrapper: Wrapper })
     expect(screen.getByText('⚡')).toBeTruthy()
   })
 
   it('chama onClick ao clicar', () => {
     const onClick = vi.fn()
-    render(<AgentAvatar agent={mockAgent} onClick={onClick} />)
-    // Clicar no container do avatar
+    render(<AgentAvatar agent={mockAgent} onClick={onClick} />, { wrapper: Wrapper })
     const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
     fireEvent.click(container)
     expect(onClick).toHaveBeenCalledWith(mockAgent)
   })
 
   it('não renderiza SpeechBubble quando speechText é null', () => {
-    render(<AgentAvatar agent={mockAgent} />)
+    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
     expect(screen.queryByText(/aguardando/i)).toBeNull()
   })
 
   it('renderiza SpeechBubble quando speechText está preenchido', () => {
-    render(<AgentAvatar agent={{ ...mockAgent, speechText: 'Analisando código' }} />)
+    render(<AgentAvatar agent={{ ...mockAgent, speechText: 'Analisando código' }} />, { wrapper: Wrapper })
     expect(screen.getByText('Analisando código')).toBeTruthy()
   })
 
   it('badge tem aria-label com o status atual', () => {
-    render(<AgentAvatar agent={mockAgent} />)
+    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
     expect(document.querySelector('[aria-label="status: idle"]')).toBeTruthy()
   })
 
   it('agente offline tem opacidade reduzida', () => {
-    render(<AgentAvatar agent={{ ...mockAgent, status: 'offline' }} />)
+    render(<AgentAvatar agent={{ ...mockAgent, status: 'offline' }} />, { wrapper: Wrapper })
     const circle = document.querySelector('[style*="opacity: 0.35"]')
     expect(circle).toBeTruthy()
+  })
+
+  it('tem aria-label com nome e status do agente', () => {
+    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
+    expect(document.querySelector('[aria-label*="Architect"]')).toBeTruthy()
+  })
+
+  it('tooltip aparece após hover (com fake timer)', () => {
+    vi.useFakeTimers()
+    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
+    const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
+    fireEvent.mouseEnter(container)
+    expect(screen.queryByRole('tooltip')).toBeNull()
+    act(() => { vi.advanceTimersByTime(400) })
+    expect(screen.getByRole('tooltip')).toBeTruthy()
+    vi.useRealTimers()
+  })
+
+  it('tooltip desaparece ao mouseLeave', () => {
+    vi.useFakeTimers()
+    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
+    const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
+    fireEvent.mouseEnter(container)
+    act(() => { vi.advanceTimersByTime(400) })
+    fireEvent.mouseLeave(container)
+    expect(screen.queryByRole('tooltip')).toBeNull()
+    vi.useRealTimers()
   })
 })

--- a/src/components/AgentAvatar.test.tsx
+++ b/src/components/AgentAvatar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { AgentAvatar } from './AgentAvatar'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
@@ -91,25 +91,26 @@ describe('AgentAvatar', () => {
     expect(document.querySelector('[aria-label*="Architect"]')).toBeTruthy()
   })
 
-  it('tooltip aparece após hover (com fake timer)', () => {
-    vi.useFakeTimers()
-    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
-    const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
-    fireEvent.mouseEnter(container)
-    expect(screen.queryByRole('tooltip')).toBeNull()
-    act(() => { vi.advanceTimersByTime(400) })
-    expect(screen.getByRole('tooltip')).toBeTruthy()
-    vi.useRealTimers()
-  })
+  describe('tooltip com fake timers', () => {
+    beforeEach(() => { vi.useFakeTimers() })
+    afterEach(() => { vi.useRealTimers() })
 
-  it('tooltip desaparece ao mouseLeave', () => {
-    vi.useFakeTimers()
-    render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
-    const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
-    fireEvent.mouseEnter(container)
-    act(() => { vi.advanceTimersByTime(400) })
-    fireEvent.mouseLeave(container)
-    expect(screen.queryByRole('tooltip')).toBeNull()
-    vi.useRealTimers()
+    it('tooltip aparece após 400ms de hover', () => {
+      render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
+      const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
+      fireEvent.mouseEnter(container)
+      expect(screen.queryByRole('tooltip')).toBeNull()
+      act(() => { vi.advanceTimersByTime(400) })
+      expect(screen.getByRole('tooltip')).toBeTruthy()
+    })
+
+    it('tooltip desaparece ao mouseLeave', () => {
+      render(<AgentAvatar agent={mockAgent} />, { wrapper: Wrapper })
+      const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
+      fireEvent.mouseEnter(container)
+      act(() => { vi.advanceTimersByTime(400) })
+      fireEvent.mouseLeave(container)
+      expect(screen.queryByRole('tooltip')).toBeNull()
+    })
   })
 })

--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -1,8 +1,10 @@
-import { memo } from 'react'
-import { motion } from 'framer-motion'
+import { memo, useState, useRef, useCallback } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
 import type { TargetAndTransition } from 'framer-motion'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
 import { SpeechBubble } from './SpeechBubble'
+import { AvatarTooltip } from './AvatarTooltip'
+import { STATUS_LABEL } from '../constants/status'
 
 interface AgentAvatarProps {
   agent: AgentOfficeData
@@ -49,16 +51,36 @@ const STATUS_BADGE_COLOR: Record<string, string> = {
   offline:   '#374151',
 }
 
+const TOOLTIP_DELAY_MS = 400
+
 export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelected = false }: AgentAvatarProps) {
   const icon = ROLE_ICON[agent.role] ?? DEFAULT_ICON
   const animation = STATUS_ANIMATION[agent.status] ?? {}
   const badgeColor = STATUS_BADGE_COLOR[agent.status] ?? '#6b7280'
   const isOffline = agent.status === 'offline'
+  const [showTooltip, setShowTooltip] = useState(false)
+  const tooltipTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleMouseEnter = useCallback(() => {
+    tooltipTimer.current = setTimeout(() => setShowTooltip(true), TOOLTIP_DELAY_MS)
+  }, [])
+
+  const handleMouseLeave = useCallback(() => {
+    if (tooltipTimer.current) clearTimeout(tooltipTimer.current)
+    setShowTooltip(false)
+  }, [])
+
+  const tooltipLines = [
+    { label: 'role', value: agent.role },
+    { label: 'status', value: STATUS_LABEL[agent.status] ?? agent.status, valueColor: badgeColor },
+    ...(agent.currentTask ? [{ label: 'task', value: agent.currentTask.slice(0, 28) + (agent.currentTask.length > 28 ? '…' : '') }] : []),
+    ...(agent.zoneId ? [{ label: 'zona', value: agent.zoneId }] : []),
+  ]
 
   return (
     <motion.div
-      // layoutId para transição suave ao mudar de zona
       layoutId={`agent-${agent.id}`}
+      aria-label={`agente ${agent.name}, status ${STATUS_LABEL[agent.status] ?? agent.status}`}
       style={{
         position: 'absolute',
         left: `${agent.position.x}%`,
@@ -73,7 +95,14 @@ export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelecte
       }}
       onClick={() => onClick?.(agent)}
       whileHover={onClick ? { scale: 1.1 } : undefined}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
+      {/* Tooltip */}
+      <AnimatePresence>
+        {showTooltip && <AvatarTooltip lines={tooltipLines} placement="top" />}
+      </AnimatePresence>
+
       {/* Balão de fala */}
       <SpeechBubble text={agent.speechText} color={agent.color} />
 

--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -4,7 +4,14 @@ import type { TargetAndTransition } from 'framer-motion'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
 import { SpeechBubble } from './SpeechBubble'
 import { AvatarTooltip } from './AvatarTooltip'
-import { STATUS_LABEL } from '../constants/status'
+
+const AGENT_STATUS_LABEL: Record<string, string> = {
+  idle:      'idle',
+  working:   'working',
+  thinking:  'thinking',
+  blocked:   'blocked',
+  offline:   'offline',
+}
 
 interface AgentAvatarProps {
   agent: AgentOfficeData
@@ -72,7 +79,7 @@ export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelecte
 
   const tooltipLines = [
     { label: 'role', value: agent.role },
-    { label: 'status', value: STATUS_LABEL[agent.status] ?? agent.status, valueColor: badgeColor },
+    { label: 'status', value: AGENT_STATUS_LABEL[agent.status] ?? agent.status, valueColor: badgeColor },
     ...(agent.currentTask ? [{ label: 'task', value: agent.currentTask.slice(0, 28) + (agent.currentTask.length > 28 ? '…' : '') }] : []),
     ...(agent.zoneId ? [{ label: 'zona', value: agent.zoneId }] : []),
   ]
@@ -80,7 +87,7 @@ export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelecte
   return (
     <motion.div
       layoutId={`agent-${agent.id}`}
-      aria-label={`agente ${agent.name}, status ${STATUS_LABEL[agent.status] ?? agent.status}`}
+      aria-label={`agente ${agent.name}, status ${AGENT_STATUS_LABEL[agent.status] ?? agent.status}`}
       style={{
         position: 'absolute',
         left: `${agent.position.x}%`,

--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useCallback } from 'react'
+import { memo, useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { TargetAndTransition } from 'framer-motion'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
@@ -77,12 +77,19 @@ export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelecte
     setShowTooltip(false)
   }, [])
 
-  const tooltipLines = [
+  // Cleanup do timer no unmount para evitar memory leak
+  useEffect(() => {
+    return () => {
+      if (tooltipTimer.current) clearTimeout(tooltipTimer.current)
+    }
+  }, [])
+
+  const tooltipLines = useMemo(() => [
     { label: 'role', value: agent.role },
     { label: 'status', value: AGENT_STATUS_LABEL[agent.status] ?? agent.status, valueColor: badgeColor },
     ...(agent.currentTask ? [{ label: 'task', value: agent.currentTask.slice(0, 28) + (agent.currentTask.length > 28 ? '…' : '') }] : []),
     ...(agent.zoneId ? [{ label: 'zona', value: agent.zoneId }] : []),
-  ]
+  ], [agent.role, agent.status, agent.currentTask, agent.zoneId, badgeColor])
 
   return (
     <motion.div

--- a/src/components/AvatarTooltip.test.tsx
+++ b/src/components/AvatarTooltip.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AvatarTooltip } from './AvatarTooltip'
+import { ThemeProvider } from '../contexts/ThemeContext'
+
+const lines = [
+  { label: 'role', value: 'architect' },
+  { label: 'status', value: 'working', valueColor: '#00ff41' },
+  { label: 'task', value: 'Revisando PR #44' },
+]
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider isHackerMode={false}>{children}</ThemeProvider>
+}
+
+describe('AvatarTooltip', () => {
+  it('tem role tooltip', () => {
+    render(<AvatarTooltip lines={lines} />, { wrapper: Wrapper })
+    expect(screen.getByRole('tooltip')).toBeTruthy()
+  })
+
+  it('exibe todas as linhas de conteúdo', () => {
+    render(<AvatarTooltip lines={lines} />, { wrapper: Wrapper })
+    expect(screen.getByText('architect')).toBeTruthy()
+    expect(screen.getByText('working')).toBeTruthy()
+    expect(screen.getByText('Revisando PR #44')).toBeTruthy()
+  })
+
+  it('exibe os labels de cada linha', () => {
+    render(<AvatarTooltip lines={lines} />, { wrapper: Wrapper })
+    expect(screen.getByText('role')).toBeTruthy()
+    expect(screen.getByText('status')).toBeTruthy()
+    expect(screen.getByText('task')).toBeTruthy()
+  })
+
+  it('renderiza com placement bottom', () => {
+    const { container } = render(
+      <AvatarTooltip lines={lines} placement="bottom" />,
+      { wrapper: Wrapper },
+    )
+    expect(container.firstChild).toBeTruthy()
+  })
+
+  it('renderiza no tema hacker', () => {
+    render(
+      <ThemeProvider isHackerMode={true}>
+        <AvatarTooltip lines={lines} />
+      </ThemeProvider>,
+    )
+    expect(screen.getByRole('tooltip')).toBeTruthy()
+  })
+})

--- a/src/components/AvatarTooltip.tsx
+++ b/src/components/AvatarTooltip.tsx
@@ -1,0 +1,74 @@
+import { memo } from 'react'
+import { motion } from 'framer-motion'
+import { useTheme } from '../contexts/ThemeContext'
+
+export interface TooltipLine {
+  label: string
+  value: string
+  valueColor?: string
+}
+
+interface AvatarTooltipProps {
+  lines: TooltipLine[]
+  /** Posiciona acima (padrão) ou abaixo */
+  placement?: 'top' | 'bottom'
+}
+
+export const AvatarTooltip = memo(function AvatarTooltip({
+  lines,
+  placement = 'top',
+}: AvatarTooltipProps) {
+  const theme = useTheme()
+
+  return (
+    <motion.div
+      role="tooltip"
+      initial={{ opacity: 0, y: placement === 'top' ? 4 : -4, scale: 0.95 }}
+      animate={{ opacity: 1, y: 0, scale: 1, transition: { duration: 0.15 } }}
+      exit={{ opacity: 0, y: placement === 'top' ? 4 : -4, scale: 0.95, transition: { duration: 0.1 } }}
+      style={{
+        position: 'absolute',
+        ...(placement === 'top'
+          ? { bottom: 'calc(100% + 8px)' }
+          : { top: 'calc(100% + 8px)' }),
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: theme.isHackerMode ? '#000000ee' : '#0d1117ee',
+        border: `1px solid ${theme.isHackerMode ? theme.zoneBorder : '#1f2937'}`,
+        borderRadius: 5,
+        padding: '6px 10px',
+        minWidth: 140,
+        zIndex: 1001,
+        pointerEvents: 'none',
+        fontFamily: 'JetBrains Mono, monospace',
+        fontSize: 10,
+        whiteSpace: 'nowrap',
+        boxShadow: theme.isHackerMode
+          ? `0 0 12px ${theme.zoneBorder}33`
+          : '0 4px 16px #00000088',
+      }}
+    >
+      {lines.map((line, i) => (
+        <div
+          key={i}
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            gap: 12,
+            lineHeight: 1.7,
+            borderTop: i > 0 && line.label === '' ? `1px solid ${theme.isHackerMode ? theme.zoneBorder + '40' : '#1f2937'}` : undefined,
+            paddingTop: i > 0 && line.label === '' ? 4 : undefined,
+            marginTop: i > 0 && line.label === '' ? 2 : undefined,
+          }}
+        >
+          <span style={{ color: theme.isHackerMode ? theme.label + 'aa' : '#4b5563' }}>
+            {line.label}
+          </span>
+          <span style={{ color: line.valueColor ?? (theme.isHackerMode ? theme.label : '#d1d5db') }}>
+            {line.value}
+          </span>
+        </div>
+      ))}
+    </motion.div>
+  )
+})

--- a/src/components/HumanAvatar.test.tsx
+++ b/src/components/HumanAvatar.test.tsx
@@ -13,8 +13,18 @@ vi.mock('framer-motion', async () => {
   return {
     ...actual,
     motion: {
-      div: ({ children, style, drag, onDragEnd: _ode, dragConstraints: _dc, dragElastic: _de, whileDrag: _wd, animate: _an, transition: _tr, ...rest }: React.HTMLAttributes<HTMLDivElement> & { drag?: boolean; onDragEnd?: unknown; dragConstraints?: unknown; dragElastic?: unknown; whileDrag?: unknown; animate?: unknown; transition?: unknown }) => (
-        <div style={style} {...(drag !== undefined ? { 'data-drag': String(drag) } : {})} {...rest}>{children}</div>
+      div: ({ children, style, drag, role, 'aria-label': ariaLabel, 'aria-grabbed': ariaGrabbed, tabIndex, onDragEnd: _ode, dragConstraints: _dc, dragElastic: _de, whileDrag: _wd, animate: _an, transition: _tr, ...rest }: React.HTMLAttributes<HTMLDivElement> & { drag?: boolean; onDragEnd?: unknown; dragConstraints?: unknown; dragElastic?: unknown; whileDrag?: unknown; animate?: unknown; transition?: unknown }) => (
+        <div
+          style={style}
+          role={role}
+          aria-label={ariaLabel}
+          aria-grabbed={ariaGrabbed}
+          tabIndex={tabIndex}
+          {...(drag !== undefined ? { 'data-drag': String(drag) } : {})}
+          {...rest}
+        >
+          {children}
+        </div>
       ),
     },
   }
@@ -61,5 +71,23 @@ describe('HumanAvatar', () => {
     const { container } = render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
     const el = container.firstChild as HTMLElement
     expect(el.getAttribute('data-drag')).toBeNull()
+  })
+
+  it('tem role=button e aria-label quando isMe=true', () => {
+    render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
+    const btn = screen.getByRole('button')
+    expect(btn).toBeTruthy()
+    expect(btn.getAttribute('aria-label')).toContain('Alice Lima')
+  })
+
+  it('não tem role=button quando isMe=false', () => {
+    render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('tem aria-label descrevendo o usuário quando isMe=false', () => {
+    const { container } = render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+    const el = container.firstChild as HTMLElement
+    expect(el.getAttribute('aria-label')).toContain('Alice Lima')
   })
 })

--- a/src/components/HumanAvatar.tsx
+++ b/src/components/HumanAvatar.tsx
@@ -46,6 +46,10 @@ export const HumanAvatar = memo(function HumanAvatar({
 
   return (
     <motion.div
+      role={isMe ? 'button' : undefined}
+      aria-label={isMe ? `seu avatar: ${user.name}, arraste para mover` : `usuário ${user.name}`}
+      aria-grabbed={isMe ? false : undefined}
+      tabIndex={isMe ? 0 : undefined}
       style={{
         position: 'absolute',
         left: `${user.x}%`,


### PR DESCRIPTION
## Issues
Closes #19 — feat(ui): tooltip de hover no AgentAvatar
Closes #45 — feat(avatar): adicionar atributos aria ao HumanAvatar

## O que foi feito

### `src/components/AvatarTooltip.tsx` (novo)
- Tooltip genérico com `motion.div` + `AnimatePresence`
- Conteúdo em linhas `{ label, value, valueColor? }`
- `placement: 'top' | 'bottom'` — padrão top
- Usa `useTheme()` — tema hacker aplica borda verde + glow
- `role="tooltip"` para acessibilidade
- `pointerEvents: none` — não bloqueia interações

### `src/components/AgentAvatar.tsx`
- `onMouseEnter` → timer 400ms → `showTooltip = true`
- `onMouseLeave` → clearTimeout + `showTooltip = false`
- Tooltip mostra: role, status (com cor), task (truncada 28 chars), zona
- `aria-label` dinâmico com nome e status do agente

### `src/components/HumanAvatar.tsx`
- `role="button"` + `aria-label="seu avatar: {name}, arraste para mover"` quando `isMe=true`
- `aria-grabbed={false}` quando arrastável
- `tabIndex={0}` quando `isMe=true`
- `aria-label="usuário {name}"` quando `isMe=false`

## Testes
- 5 testes em `AvatarTooltip.test.tsx`
- +3 testes em `AgentAvatar.test.tsx` (tooltip + aria)
- +3 testes em `HumanAvatar.test.tsx` (ARIA)
- Total: **137 testes passando** (antes: 126)

## Checklist
- [x] Testes passando (137/137)
- [x] TypeScript sem erros
- [x] ESLint sem warnings