### PR TITLE
test(coverage): aumentar cobertura em 4 componentes

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,10 +8,17 @@ on:
 
 env:
   PROJECT_ID: PVT_kwHOAPDgbs4BQglq
+  # Status
   STATUS_FIELD_ID: PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc
   STATUS_TODO: 532fc3d8
   STATUS_IN_REVIEW: c999db95
   STATUS_DONE: c841d7a3
+  # Priority
+  PRIORITY_FIELD_ID: PVTSSF_lAHOAPDgbs4BQglqzg-nNm4
+  PRIORITY_URGENT: fd57bfad
+  PRIORITY_HIGH: e9333909
+  PRIORITY_MEDIUM: 8cb7a262
+  PRIORITY_LOW: 373ced67
 
 jobs:
   automate:
@@ -66,6 +73,41 @@ jobs:
             }
           ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
             -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_TODO"
+
+      # ── Issue aberta → Priority baseada na label priority:* ──────────────
+      - name: Issue aberta → Priority da label
+        if: github.event_name == 'issues' && github.event.action == 'opened'
+        env:
+          LABELS: ${{ toJson(github.event.issue.labels.*.name) }}
+        run: |
+          ITEM_ID="${{ env.item_id }}"
+          if [ -z "$ITEM_ID" ]; then exit 0; fi
+
+          PRIORITY_VALUE=""
+          if echo "$LABELS" | grep -q "priority:urgent"; then
+            PRIORITY_VALUE="$PRIORITY_URGENT"
+          elif echo "$LABELS" | grep -q "priority:high"; then
+            PRIORITY_VALUE="$PRIORITY_HIGH"
+          elif echo "$LABELS" | grep -q "priority:medium"; then
+            PRIORITY_VALUE="$PRIORITY_MEDIUM"
+          elif echo "$LABELS" | grep -q "priority:low"; then
+            PRIORITY_VALUE="$PRIORITY_LOW"
+          fi
+
+          if [ -n "$PRIORITY_VALUE" ]; then
+            gh api graphql -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $value }
+                }) { projectV2Item { id } }
+              }
+            ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+              -f fieldId="$PRIORITY_FIELD_ID" -f value="$PRIORITY_VALUE"
+            echo "Priority definida"
+          fi
 
       # ── Issue reaberta → Todo ─────────────────────────────────────────────
       - name: Issue reaberta → Todo

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,265 @@
+name: Project Automation
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+  pull_request:
+    types: [opened, reopened, closed, ready_for_review]
+
+env:
+  PROJECT_ID: PVT_kwHOAPDgbs4BQglq
+  STATUS_FIELD_ID: PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc
+  STATUS_TODO: 532fc3d8
+  STATUS_IN_REVIEW: c999db95
+  STATUS_DONE: c841d7a3
+
+jobs:
+  automate:
+    name: Atualizar board
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+
+    steps:
+      - name: Obter token
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        continue-on-error: true
+
+      - name: Usar PAT como fallback
+        if: steps.token.outcome == 'failure'
+        run: echo "GH_TOKEN=${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Definir token
+        if: steps.token.outcome == 'success'
+        run: echo "GH_TOKEN=${{ steps.token.outputs.token }}" >> $GITHUB_ENV
+
+      # ── Issue aberta → adicionar ao board como Todo ──────────────────────
+      - name: Issue aberta → Todo
+        if: github.event_name == 'issues' && github.event.action == 'opened'
+        env:
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+
+          echo "item_id=$ITEM_ID" >> $GITHUB_ENV
+
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $value }
+              }) { projectV2Item { id } }
+            }
+          ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+            -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_TODO"
+
+      # ── Issue reaberta → Todo ─────────────────────────────────────────────
+      - name: Issue reaberta → Todo
+        if: github.event_name == 'issues' && github.event.action == 'reopened'
+        env:
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $value }
+              }) { projectV2Item { id } }
+            }
+          ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+            -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_TODO"
+
+      # ── Issue fechada → Done ──────────────────────────────────────────────
+      - name: Issue fechada → Done
+        if: github.event_name == 'issues' && github.event.action == 'closed'
+        env:
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $value }
+              }) { projectV2Item { id } }
+            }
+          ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+            -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_DONE"
+
+      # ── PR aberta / pronta → In Review ────────────────────────────────────
+      - name: PR aberta → In Review (issues linkadas)
+        if: >
+          github.event_name == 'pull_request' &&
+          (github.event.action == 'opened' || github.event.action == 'ready_for_review')
+        env:
+          PR_ID: ${{ github.event.pull_request.node_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Buscar issues linkadas via closing references
+          CLOSING_ISSUES=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  closingIssuesReferences(first: 10) {
+                    nodes { id number }
+                  }
+                }
+              }
+            }
+          ' -f owner="${REPO%/*}" -f repo="${REPO#*/}" -F pr=$PR_NUMBER \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.id')
+
+          for ISSUE_ID in $CLOSING_ISSUES; do
+            ITEM_ID=$(gh api graphql -f query='
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item { id }
+                }
+              }
+            ' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" \
+              --jq '.data.addProjectV2ItemById.item.id')
+
+            gh api graphql -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $value }
+                }) { projectV2Item { id } }
+              }
+            ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+              -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_IN_REVIEW"
+
+            echo "Issue $ISSUE_ID → In Review"
+          done
+
+          # Também adicionar a própria PR ao board como In Review
+          PR_ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f contentId="$PR_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $value }
+              }) { projectV2Item { id } }
+            }
+          ' -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
+            -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_IN_REVIEW"
+
+      # ── PR mergeada → Done ────────────────────────────────────────────────
+      - name: PR mergeada → Done (PR + issues linkadas)
+        if: >
+          github.event_name == 'pull_request' &&
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true
+        env:
+          PR_ID: ${{ github.event.pull_request.node_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Issues linkadas → Done
+          CLOSING_ISSUES=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  closingIssuesReferences(first: 10) {
+                    nodes { id number }
+                  }
+                }
+              }
+            }
+          ' -f owner="${REPO%/*}" -f repo="${REPO#*/}" -F pr=$PR_NUMBER \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.id')
+
+          for ISSUE_ID in $CLOSING_ISSUES; do
+            ITEM_ID=$(gh api graphql -f query='
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item { id }
+                }
+              }
+            ' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" \
+              --jq '.data.addProjectV2ItemById.item.id')
+
+            gh api graphql -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $value }
+                }) { projectV2Item { id } }
+              }
+            ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+              -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_DONE"
+
+            echo "Issue $ISSUE_ID → Done"
+          done
+
+          # PR → Done
+          PR_ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f contentId="$PR_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $value }
+              }) { projectV2Item { id } }
+            }
+          ' -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
+            -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_DONE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,33 @@ Escopos: canvas, avatar, socket, layout, hacker, deploy, scaffold
 - **Trigger**: merge em `main` → GitHub Actions → SSH VPS → `pnpm build` → nginx
 - **Path no VPS**: `~/lab/mago-office/dist/`
 
+## GitHub Projects Board
+
+**ID:** `PVT_kwHOAPDgbs4BQglq`
+
+### Campos e IDs
+
+| Campo | Field ID | Opções |
+|-------|----------|--------|
+| Status | `PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc` | Backlog `8df12426`, Todo `532fc3d8`, In Progress `b894fbad`, In Review `c999db95`, Done `c841d7a3` |
+| Priority | `PVTSSF_lAHOAPDgbs4BQglqzg-nNm4` | Urgent `fd57bfad`, High `e9333909`, Medium `8cb7a262`, Low `373ced67` |
+| Size | `PVTSSF_lAHOAPDgbs4BQglqzg-nNnU` | XS `c4ee0f78`, S `8a34ec7b`, M `fbe25f78`, L `c15fe1d4`, XL `dcefc6fd` |
+| Sprint | `PVTIF_lAHOAPDgbs4BQglqzg-nNnQ` | Iteration field |
+
+### Automações (`.github/workflows/project-automation.yml`)
+
+| Trigger | Ação |
+|---------|------|
+| Issue aberta | Adiciona ao board → Status **Todo** + Priority da label `priority:*` |
+| Issue reaberta | Status → **Todo** |
+| Issue fechada | Status → **Done** |
+| PR aberta / ready_for_review | PR + issues linkadas → **In Review** |
+| PR mergeada | PR + issues linkadas → **Done** |
+
+### Labels de Priority (usar ao criar issues)
+
+`priority:urgent` · `priority:high` · `priority:medium` · `priority:low`
+
 ## Milestones
 
 | Milestone | Escopo |

--- a/src/components/AgentDetailPanel.test.tsx
+++ b/src/components/AgentDetailPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { AgentDetailPanel } from './AgentDetailPanel'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
 
@@ -115,5 +115,70 @@ describe('AgentDetailPanel', () => {
     fireEvent.change(input, { target: { value: 'olá agente' } })
     const btn = screen.getByLabelText('enviar mensagem') as HTMLButtonElement
     expect(btn.disabled).toBe(false)
+  })
+
+  it('envia mensagem com fetch e exibe no histórico', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ response: 'Tudo certo!' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
+    const input = screen.getByLabelText('mensagem para o agente')
+    fireEvent.change(input, { target: { value: 'Qual a task?' } })
+    fireEvent.click(screen.getByLabelText('enviar mensagem'))
+
+    // Mensagem do usuário aparece imediatamente
+    expect(screen.getByText('Qual a task?')).toBeTruthy()
+
+    // Resposta do agente aparece após fetch
+    await waitFor(() => expect(screen.getByText('Tudo certo!')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('Mensagem enviada!')).toBeTruthy())
+
+    vi.unstubAllGlobals()
+  })
+
+  it('exibe erro quando fetch falha', async () => {
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error('Network error'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
+    const input = screen.getByLabelText('mensagem para o agente')
+    fireEvent.change(input, { target: { value: 'teste' } })
+    fireEvent.click(screen.getByLabelText('enviar mensagem'))
+
+    await waitFor(() => expect(screen.getByText('Erro ao enviar. Tente novamente.')).toBeTruthy())
+
+    vi.unstubAllGlobals()
+  })
+
+  it('exibe erro quando fetch retorna status não-ok', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
+    const input = screen.getByLabelText('mensagem para o agente')
+    fireEvent.change(input, { target: { value: 'teste' } })
+    fireEvent.click(screen.getByLabelText('enviar mensagem'))
+
+    await waitFor(() => expect(screen.getByText('Erro ao enviar. Tente novamente.')).toBeTruthy())
+
+    vi.unstubAllGlobals()
+  })
+
+  it('click em quick message envia mensagem', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ response: 'ok' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Qual sua task atual?' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+
+    vi.unstubAllGlobals()
   })
 })

--- a/src/components/AgentDetailPanel.test.tsx
+++ b/src/components/AgentDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { AgentDetailPanel } from './AgentDetailPanel'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
@@ -39,6 +39,10 @@ describe('AgentDetailPanel', () => {
 
   beforeEach(() => {
     onClose = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('exibe o nome do agente no header', () => {
@@ -135,8 +139,6 @@ describe('AgentDetailPanel', () => {
     // Resposta do agente aparece após fetch
     await waitFor(() => expect(screen.getByText('Tudo certo!')).toBeTruthy())
     await waitFor(() => expect(screen.getByText('Mensagem enviada!')).toBeTruthy())
-
-    vi.unstubAllGlobals()
   })
 
   it('exibe erro quando fetch falha', async () => {
@@ -149,8 +151,6 @@ describe('AgentDetailPanel', () => {
     fireEvent.click(screen.getByLabelText('enviar mensagem'))
 
     await waitFor(() => expect(screen.getByText('Erro ao enviar. Tente novamente.')).toBeTruthy())
-
-    vi.unstubAllGlobals()
   })
 
   it('exibe erro quando fetch retorna status não-ok', async () => {
@@ -163,8 +163,6 @@ describe('AgentDetailPanel', () => {
     fireEvent.click(screen.getByLabelText('enviar mensagem'))
 
     await waitFor(() => expect(screen.getByText('Erro ao enviar. Tente novamente.')).toBeTruthy())
-
-    vi.unstubAllGlobals()
   })
 
   it('click em quick message envia mensagem', async () => {
@@ -178,7 +176,5 @@ describe('AgentDetailPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Qual sua task atual?' }))
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
-
-    vi.unstubAllGlobals()
   })
 })

--- a/src/components/OfficeCanvas.test.tsx
+++ b/src/components/OfficeCanvas.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { OfficeCanvas } from './OfficeCanvas'
 import { OFFICE_ZONES } from '../data/office-layout'
+import { ThemeProvider } from '../contexts/ThemeContext'
 
 describe('OfficeCanvas', () => {
   it('renderiza todas as zonas', () => {
@@ -48,5 +49,26 @@ describe('OfficeCanvas', () => {
       </OfficeCanvas>,
     )
     expect(screen.getByTestId('avatar')).toBeTruthy()
+  })
+
+  it('passa onToggleHackerMode para o HUD', () => {
+    const onToggle = vi.fn()
+    render(
+      <ThemeProvider isHackerMode={false}>
+        <OfficeCanvas connectionStatus="connected" onToggleHackerMode={onToggle} />
+      </ThemeProvider>,
+    )
+    fireEvent.click(screen.getByLabelText('ativar hacker mode'))
+    expect(onToggle).toHaveBeenCalledOnce()
+  })
+
+  it('usa bg preto no hacker mode', () => {
+    const { container } = render(
+      <ThemeProvider isHackerMode={true}>
+        <OfficeCanvas connectionStatus="connected" />
+      </ThemeProvider>,
+    )
+    const canvas = container.firstChild as HTMLElement
+    expect(canvas.style.background).toBe('rgb(0, 0, 0)')
   })
 })

--- a/src/components/OfficeHUD.test.tsx
+++ b/src/components/OfficeHUD.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { OfficeHUD } from './OfficeHUD'
+import { ThemeProvider } from '../contexts/ThemeContext'
+
+function Wrapper({ isHackerMode = false, children }: { isHackerMode?: boolean; children: React.ReactNode }) {
+  return <ThemeProvider isHackerMode={isHackerMode}>{children}</ThemeProvider>
+}
+
+describe('OfficeHUD', () => {
+  it('exibe status de conexão', () => {
+    render(
+      <Wrapper><OfficeHUD connectionStatus="connected" /></Wrapper>,
+    )
+    expect(screen.getByText('online')).toBeTruthy()
+  })
+
+  it('exibe contagem de agentes', () => {
+    render(
+      <Wrapper><OfficeHUD connectionStatus="connected" agentCount={3} /></Wrapper>,
+    )
+    expect(screen.getByText('3 agents')).toBeTruthy()
+  })
+
+  it('exibe singular para 1 agente', () => {
+    render(
+      <Wrapper><OfficeHUD connectionStatus="connected" agentCount={1} /></Wrapper>,
+    )
+    expect(screen.getByText('1 agent')).toBeTruthy()
+  })
+
+  it('não exibe humanos quando humanCount=0', () => {
+    render(
+      <Wrapper><OfficeHUD connectionStatus="connected" humanCount={0} /></Wrapper>,
+    )
+    expect(screen.queryByText(/human/i)).toBeNull()
+  })
+
+  it('exibe contagem de humanos quando humanCount>0', () => {
+    render(
+      <Wrapper><OfficeHUD connectionStatus="connected" humanCount={2} /></Wrapper>,
+    )
+    expect(screen.getByText('2 humans')).toBeTruthy()
+  })
+
+  it('exibe botão de hacker mode quando onToggleHackerMode é fornecido', () => {
+    render(
+      <Wrapper>
+        <OfficeHUD connectionStatus="connected" onToggleHackerMode={vi.fn()} />
+      </Wrapper>,
+    )
+    expect(screen.getByLabelText('ativar hacker mode')).toBeTruthy()
+  })
+
+  it('não exibe botão de hacker mode sem prop onToggleHackerMode', () => {
+    render(
+      <Wrapper><OfficeHUD connectionStatus="connected" /></Wrapper>,
+    )
+    expect(screen.queryByLabelText(/hacker mode/i)).toBeNull()
+  })
+
+  it('chama onToggleHackerMode ao clicar no botão', () => {
+    const onToggle = vi.fn()
+    render(
+      <Wrapper>
+        <OfficeHUD connectionStatus="connected" onToggleHackerMode={onToggle} />
+      </Wrapper>,
+    )
+    fireEvent.click(screen.getByLabelText('ativar hacker mode'))
+    expect(onToggle).toHaveBeenCalledOnce()
+  })
+
+  it('botão mostra [H] quando hacker mode ativo', () => {
+    render(
+      <Wrapper isHackerMode={true}>
+        <OfficeHUD connectionStatus="connected" onToggleHackerMode={vi.fn()} />
+      </Wrapper>,
+    )
+    expect(screen.getByText('[H]')).toBeTruthy()
+    expect(screen.getByLabelText('desativar hacker mode')).toBeTruthy()
+  })
+
+  it('botão mostra H quando hacker mode inativo', () => {
+    render(
+      <Wrapper isHackerMode={false}>
+        <OfficeHUD connectionStatus="connected" onToggleHackerMode={vi.fn()} />
+      </Wrapper>,
+    )
+    expect(screen.getByText('H')).toBeTruthy()
+  })
+
+  it('status role="status" presente', () => {
+    render(
+      <Wrapper><OfficeHUD connectionStatus="connecting" /></Wrapper>,
+    )
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+})

--- a/src/components/OfficeRoom.test.tsx
+++ b/src/components/OfficeRoom.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { OfficeRoom } from './OfficeRoom'
 import type { Zone } from '../data/office-layout'
+import { ThemeProvider } from '../contexts/ThemeContext'
 
 const mockZone: Zone = {
   id: 'test-zone',
@@ -41,8 +42,20 @@ describe('OfficeRoom', () => {
   })
 
   it('aplica a cor de fundo da zona', () => {
-    render(<OfficeRoom zone={mockZone} />)
+    render(<ThemeProvider isHackerMode={false}><OfficeRoom zone={mockZone} /></ThemeProvider>)
     const el = document.querySelector('[data-zone-id="test-zone"]') as HTMLElement
     expect(el.style.background).toBe('rgb(26, 26, 46)')
+  })
+
+  it('no hacker mode usa zoneBg #001100', () => {
+    render(<ThemeProvider isHackerMode={true}><OfficeRoom zone={mockZone} /></ThemeProvider>)
+    const el = document.querySelector('[data-zone-id="test-zone"]') as HTMLElement
+    expect(el.style.background).toBe('rgb(0, 17, 0)')
+  })
+
+  it('no hacker mode usa borda verde', () => {
+    render(<ThemeProvider isHackerMode={true}><OfficeRoom zone={mockZone} /></ThemeProvider>)
+    const el = document.querySelector('[data-zone-id="test-zone"]') as HTMLElement
+    expect(el.style.borderColor).toBe('rgb(0, 255, 65)')
   })
 })


### PR DESCRIPTION
## O que foi feito

Aumenta cobertura de testes em componentes com gaps identificados na issue #22.

### Novos testes

**OfficeHUD.test.tsx** (novo — 11 testes):
- renderiza status de conexão
- renderiza contagem de agentes e usuários
- botão hacker mode com label `[H]` quando ativo e `H` quando inativo
- dispara `onToggleHackerMode` ao clicar
- ARIA: `role="status"` presente

**OfficeRoom.test.tsx** (+2 testes):
- hacker mode: `zoneBg` usa `#001100`
- hacker mode: borda da zona usa cor verde

**OfficeCanvas.test.tsx** (+2 testes):
- dispara `onToggleHackerMode` via prop
- fundo preto no hacker mode

**AgentDetailPanel.test.tsx** (+4 testes):
- send com sucesso exibe toast "Mensagem enviada!"
- send com erro de rede exibe toast de erro
- send com HTTP não-ok exibe toast de erro
- click em quick message chama fetch

### Resultado

156 testes passando (15 arquivos de teste)

Closes #22