### PR TITLE
chore(scripts): revisar workflow completo e corrigir bugs criticos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,18 +32,4 @@ jobs:
           port: 22
           timeout: 120s
           script: |
-            set -e
-            echo "=== Deploy mago-office ==="
-            cd ~/lab/mago-office
-
-            echo "--- Git pull ---"
-            git pull origin main --ff-only
-
-            echo "--- Instalar dependências ---"
-            COREPACK_ENABLE_STRICT=0 pnpm install --frozen-lockfile
-
-            echo "--- Build ---"
-            pnpm build
-
-            echo "=== Deploy concluído ==="
-            echo "office.iae.wtf serving dist/"
+            bash ~/lab/mago-office/scripts/deploy.sh

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -2,15 +2,19 @@ name: Project Automation
 
 on:
   issues:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, closed, labeled]
   pull_request:
     types: [opened, reopened, closed, ready_for_review]
+  discussion:
+    types: [created]
 
 env:
   PROJECT_ID: PVT_kwHOAPDgbs4BQglq
   # Status
   STATUS_FIELD_ID: PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc
+  STATUS_BACKLOG: 8df12426
   STATUS_TODO: 532fc3d8
+  STATUS_IN_PROGRESS: b894fbad
   STATUS_IN_REVIEW: c999db95
   STATUS_DONE: c841d7a3
   # Priority
@@ -19,14 +23,21 @@ env:
   PRIORITY_HIGH: e9333909
   PRIORITY_MEDIUM: 8cb7a262
   PRIORITY_LOW: 373ced67
+  # Size
+  SIZE_FIELD_ID: PVTSSF_lAHOAPDgbs4BQglqzg-nNnU
+  SIZE_XS: c4ee0f78
+  SIZE_S: 8a34ec7b
+  SIZE_M: fbe25f78
+  SIZE_L: c15fe1d4
+  SIZE_XL: dcefc6fd
 
 jobs:
   automate:
     name: Atualizar board
     runs-on: ubuntu-latest
     permissions:
-      issues: read
-      pull-requests: read
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Obter token
@@ -39,7 +50,14 @@ jobs:
 
       - name: Usar PAT como fallback
         if: steps.token.outcome == 'failure'
-        run: echo "GH_TOKEN=${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+        # GITHUB_TOKEN não tem scope 'project' — requer GH_PAT com project:write
+        run: |
+          if [ -z "${{ secrets.GH_PAT }}" ]; then
+            echo "⚠️  GH_PAT não configurado. Automações do board não funcionarão."
+            echo "   Configure o secret GH_PAT com scope: project, repo"
+            exit 1
+          fi
+          echo "GH_TOKEN=${{ secrets.GH_PAT }}" >> $GITHUB_ENV
 
       - name: Definir token
         if: steps.token.outcome == 'success'
@@ -305,3 +323,97 @@ jobs:
             }
           ' -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
             -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_DONE"
+
+      # ── Issue etiquetada → atualizar Priority ou Size ─────────────────────
+      - name: Issue etiquetada → Priority ou Size
+        if: github.event_name == 'issues' && github.event.action == 'labeled'
+        env:
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          # Garantir que a issue está no board e obter item_id
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+
+          # Priority
+          if [[ "$LABEL_NAME" == priority:* ]]; then
+            case "${LABEL_NAME#priority:}" in
+              urgent) FIELD_VALUE="$PRIORITY_URGENT" ;;
+              high)   FIELD_VALUE="$PRIORITY_HIGH"   ;;
+              medium) FIELD_VALUE="$PRIORITY_MEDIUM" ;;
+              low)    FIELD_VALUE="$PRIORITY_LOW"    ;;
+              *)      FIELD_VALUE="" ;;
+            esac
+            if [ -n "$FIELD_VALUE" ]; then
+              gh api graphql -f query='
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId itemId: $itemId fieldId: $fieldId
+                    value: { singleSelectOptionId: $value }
+                  }) { projectV2Item { id } }
+                }
+              ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+                -f fieldId="$PRIORITY_FIELD_ID" -f value="$FIELD_VALUE"
+              echo "Priority → ${LABEL_NAME#priority:}"
+            fi
+          fi
+
+          # Size
+          if [[ "$LABEL_NAME" == size:* ]]; then
+            case "${LABEL_NAME#size:}" in
+              xs) FIELD_VALUE="$SIZE_XS" ;;
+              s)  FIELD_VALUE="$SIZE_S"  ;;
+              m)  FIELD_VALUE="$SIZE_M"  ;;
+              l)  FIELD_VALUE="$SIZE_L"  ;;
+              xl) FIELD_VALUE="$SIZE_XL" ;;
+              *)  FIELD_VALUE="" ;;
+            esac
+            if [ -n "$FIELD_VALUE" ]; then
+              gh api graphql -f query='
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId itemId: $itemId fieldId: $fieldId
+                    value: { singleSelectOptionId: $value }
+                  }) { projectV2Item { id } }
+                }
+              ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+                -f fieldId="$SIZE_FIELD_ID" -f value="$FIELD_VALUE"
+              echo "Size → ${LABEL_NAME#size:}"
+            fi
+          fi
+
+      # ── Discussion criada → Backlog ───────────────────────────────────────
+      - name: Discussion criada → Backlog
+        if: github.event_name == 'discussion' && github.event.action == 'created'
+        env:
+          DISCUSSION_ID: ${{ github.event.discussion.node_id }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f contentId="$DISCUSSION_ID" \
+            --jq '.data.addProjectV2ItemById.item.id') || true
+
+          if [ -n "$ITEM_ID" ]; then
+            gh api graphql -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId itemId: $itemId fieldId: $fieldId
+                  value: { singleSelectOptionId: $value }
+                }) { projectV2Item { id } }
+              }
+            ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+              -f fieldId="$STATUS_FIELD_ID" -f value="$STATUS_BACKLOG" || true
+            echo "Discussion → Backlog"
+          else
+            echo "Discussion não pôde ser adicionada ao board (API pode não suportar)"
+          fi

--- a/scripts/branch-create.sh
+++ b/scripts/branch-create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Cria branch padronizada a partir de issue
+# Cria branch padronizada a partir de issue + atualiza board para In Progress
 # Uso: ./scripts/branch-create.sh <issue-number>
 
 set -e
@@ -17,19 +17,22 @@ cd /home/rx/lab/mago-office
 TITLE=$(gh issue view "$ISSUE" --repo roxdavirox/mago-office --json title -q .title)
 
 if [[ -z "$TITLE" ]]; then
-  echo "Erro: Issue #$ISSUE nao encontrada"
+  echo "Erro: Issue #$ISSUE não encontrada"
   exit 1
 fi
 
 TYPE=$(echo "$TITLE" | grep -oP '^\[?\K\w+' | tr '[:upper:]' '[:lower:]' | head -1)
 case $TYPE in
-  scaffold|ci|chore|dx) TYPE="chore" ;;
-  test) TYPE="test" ;;
-  fix) TYPE="fix" ;;
-  *) TYPE="feat" ;;
+  scaffold|ci|chore|dx) TYPE="chore"    ;;
+  test)                  TYPE="test"     ;;
+  fix)                   TYPE="fix"      ;;
+  refactor)              TYPE="refactor" ;;
+  docs)                  TYPE="docs"     ;;
+  *)                     TYPE="feat"     ;;
 esac
 
-SLUG=$(echo "$TITLE" | sed 's/.*: //' | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-' | cut -c1-35)
+SLUG=$(echo "$TITLE" | sed 's/.*: //' | tr '[:upper:]' '[:lower:]' \
+  | tr ' ' '-' | tr -cd 'a-z0-9-' | sed 's/^-*//' | cut -c1-35)
 
 BRANCH="$TYPE/issue-$ISSUE-$SLUG"
 
@@ -40,14 +43,45 @@ git checkout -b "$BRANCH"
 echo ""
 echo "Branch criada: $BRANCH"
 
-# Consultar rx-architect para estimativa e plano de implementação
+# ── Mover issue para In Progress no board ─────────────────────────────────────
+PROJECT_ID="PVT_kwHOAPDgbs4BQglq"
+STATUS_FIELD="PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc"
+S_IN_PROGRESS="b894fbad"
+
+ISSUE_NODE=$(gh api "repos/roxdavirox/mago-office/issues/$ISSUE" \
+  --jq '.node_id' 2>/dev/null || echo "")
+
+if [[ -n "$ISSUE_NODE" ]]; then
+  ITEM_ID=$(gh api graphql -f query='
+    mutation($p:ID!,$c:ID!){
+      addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}
+    }' -f p="$PROJECT_ID" -f c="$ISSUE_NODE" \
+    --jq '.data.addProjectV2ItemById.item.id' 2>/dev/null || echo "")
+
+  if [[ -n "$ITEM_ID" ]]; then
+    gh api graphql -f query='
+      mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){
+        updateProjectV2ItemFieldValue(input:{
+          projectId:$p itemId:$i fieldId:$f
+          value:{singleSelectOptionId:$v}
+        }){projectV2Item{id}}
+      }' -f p="$PROJECT_ID" -f i="$ITEM_ID" \
+      -f f="$STATUS_FIELD" -f v="$S_IN_PROGRESS" > /dev/null 2>&1 \
+      && echo "Board: #$ISSUE → In Progress" \
+      || echo "⚠️  Board não atualizado (verificar permissões)"
+  fi
+fi
+
+# ── Consultar rx-architect para estimativa ────────────────────────────────────
 CELEBRO_URL="${CELEBRO_URL:-http://localhost:3099/chat}"
-if curl -s --connect-timeout 2 "$CELEBRO_URL" > /dev/null 2>&1 || true; then
+if curl -s --connect-timeout 2 "$CELEBRO_URL" > /dev/null 2>&1; then
   echo ""
   echo "🏗️  Consultando rx-architect..."
   bash "$(dirname "$0")/mago-estimate.sh" "$ISSUE" --board --comment 2>/dev/null \
     || echo "⚠️  rx-architect indisponível (continuando sem estimativa)"
+else
+  echo "⚠️  Celebro offline — estimativa pulada"
 fi
 
 echo ""
-echo "Próximo: git add . && git commit && ./scripts/pr-create.sh"
+echo "Próximo: implemente, commite e rode ./scripts/pr-create.sh $ISSUE"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,5 +24,10 @@ COREPACK_ENABLE_STRICT=0 pnpm install --frozen-lockfile
 echo "--- Build ---"
 COREPACK_ENABLE_STRICT=0 pnpm build
 
+if [ ! -f "dist/index.html" ]; then
+  echo "❌ Build falhou: dist/index.html não encontrado"
+  exit 1
+fi
+
 echo "=== Deploy concluído ==="
-echo "URL: http://office.iae.wtf"
+echo "URL: https://office.iae.wtf"

--- a/scripts/mago-board.sh
+++ b/scripts/mago-board.sh
@@ -1,0 +1,529 @@
+#!/bin/bash
+# scripts/mago-board.sh — Gerenciamento completo do GitHub Projects board
+#
+# Subcomandos:
+#   status               — Visão geral por coluna (Status)
+#   backfill             — Preencher Priority+Size em itens sem esses campos
+#   sync                 — Adicionar issues/PRs/discussions faltando no board
+#   report               — Relatório markdown completo
+#   set <N> <campo> <v>  — Atualizar campo de um item (priority|size|status)
+#   discuss              — Listar discussions e estado no board
+#
+# Exemplos:
+#   bash scripts/mago-board.sh status
+#   bash scripts/mago-board.sh backfill
+#   bash scripts/mago-board.sh sync
+#   bash scripts/mago-board.sh set 47 priority high
+#   bash scripts/mago-board.sh set 47 size m
+
+set -e
+
+# ── Constantes ────────────────────────────────────────────────────────────────
+PROJECT_ID="PVT_kwHOAPDgbs4BQglq"
+REPO="roxdavirox/mago-office"
+
+# Fields
+STATUS_FIELD="PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc"
+PRIORITY_FIELD="PVTSSF_lAHOAPDgbs4BQglqzg-nNm4"
+SIZE_FIELD="PVTSSF_lAHOAPDgbs4BQglqzg-nNnU"
+
+# Status options
+S_BACKLOG="8df12426"
+S_TODO="532fc3d8"
+S_IN_PROGRESS="b894fbad"
+S_IN_REVIEW="c999db95"
+S_DONE="c841d7a3"
+
+# Priority options
+P_URGENT="fd57bfad"
+P_HIGH="e9333909"
+P_MEDIUM="8cb7a262"
+P_LOW="373ced67"
+
+# Size options
+SZ_XS="c4ee0f78"
+SZ_S="8a34ec7b"
+SZ_M="fbe25f78"
+SZ_L="c15fe1d4"
+SZ_XL="dcefc6fd"
+
+CMD="${1:-status}"
+shift || true
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Busca todos os itens do board com campos preenchidos
+get_items() {
+  gh api graphql -f query="
+  {
+    node(id: \"$PROJECT_ID\") {
+      ... on ProjectV2 {
+        items(first: 100) {
+          nodes {
+            id
+            content {
+              ... on Issue        { number title state labels(first:8){nodes{name}} }
+              ... on PullRequest  { number title state }
+              ... on DraftIssue  { title }
+            }
+            fieldValues(first: 10) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name optionId
+                  field { ... on ProjectV2SingleSelectField { name } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }"
+}
+
+# Atualiza um campo single-select de um item do board
+set_field() {
+  local ITEM_ID="$1" FIELD_ID="$2" VALUE_ID="$3"
+  gh api graphql -f query='
+    mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){
+      updateProjectV2ItemFieldValue(input:{
+        projectId:$p itemId:$i fieldId:$f
+        value:{singleSelectOptionId:$v}
+      }){projectV2Item{id}}
+    }' \
+    -f p="$PROJECT_ID" -f i="$ITEM_ID" \
+    -f f="$FIELD_ID" -f v="$VALUE_ID" > /dev/null 2>&1
+}
+
+# Adiciona um item ao board pelo node_id (idempotente)
+add_to_board() {
+  local CONTENT_ID="$1"
+  gh api graphql -f query='
+    mutation($p:ID!,$c:ID!){
+      addProjectV2ItemById(input:{projectId:$p,contentId:$c}){
+        item{id}
+      }
+    }' \
+    -f p="$PROJECT_ID" -f c="$CONTENT_ID" \
+    --jq '.data.addProjectV2ItemById.item.id' 2>/dev/null || echo ""
+}
+
+# ── Comandos ──────────────────────────────────────────────────────────────────
+
+case "$CMD" in
+
+# ── status ────────────────────────────────────────────────────────────────────
+status)
+  echo "━━━ Board: mago-office ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  get_items | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+items = data['data']['node']['items']['nodes']
+
+by_status = {}
+missing_fields = []
+
+for item in items:
+    c = item.get('content', {})
+    if not c: continue
+    num = c.get('number', '?')
+    title = c.get('title', '?')[:52]
+    fvs = {fv.get('field',{}).get('name'): fv.get('name','—') for fv in item['fieldValues']['nodes'] if fv}
+    status   = fvs.get('Status',   '—')
+    priority = fvs.get('Priority', '—')
+    size     = fvs.get('Size',     '—')
+    by_status.setdefault(status, []).append((num, title, priority, size))
+    if priority == '—' or size == '—':
+        missing_fields.append(num)
+
+icons = {'Todo':'📋','In Progress':'🔄','In Review':'👀','Backlog':'🗂️','Done':'✅','—':'❓'}
+order = ['Todo','In Progress','In Review','Backlog','Done','—']
+
+for s in order:
+    if s not in by_status: continue
+    lst = by_status[s]
+    print(f'\n{icons.get(s,\"\")} {s} ({len(lst)})')
+    for num, title, p, sz in lst:
+        p_flag  = '⚠️ ' if p  == '—' else ''
+        sz_flag = '⚠️ ' if sz == '—' else ''
+        print(f'  #{num:3}  [{sz_flag}{sz:3}]  {p_flag}{p:8}  {title}')
+
+total = sum(len(v) for v in by_status.values())
+print(f'\nTotal: {total} itens')
+if missing_fields:
+    print(f'⚠️  Campos faltando em: #{\", #\".join(str(n) for n in missing_fields)}')
+    print('   → Execute: bash scripts/mago-board.sh backfill')
+"
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  ;;
+
+# ── backfill ──────────────────────────────────────────────────────────────────
+backfill)
+  echo "⚙️  Backfill: preenchendo Priority + Size em todos os itens..."
+  echo ""
+
+  get_items | python3 -c "
+import sys, json, subprocess
+
+data = json.load(sys.stdin)
+items = data['data']['node']['items']['nodes']
+
+PROJECT_ID    = 'PVT_kwHOAPDgbs4BQglq'
+PRIORITY_FIELD = 'PVTSSF_lAHOAPDgbs4BQglqzg-nNm4'
+SIZE_FIELD     = 'PVTSSF_lAHOAPDgbs4BQglqzg-nNnU'
+
+P  = {'urgent':'fd57bfad','high':'e9333909','medium':'8cb7a262','low':'373ced67'}
+SZ = {'xs':'c4ee0f78','s':'8a34ec7b','m':'fbe25f78','l':'c15fe1d4','xl':'dcefc6fd'}
+
+def infer_priority(labels, title):
+    for l in labels:
+        if l == 'priority:urgent': return 'urgent'
+        if l == 'priority:high':   return 'high'
+        if l == 'priority:medium': return 'medium'
+        if l == 'priority:low':    return 'low'
+    t = title.lower()
+    high_kw = ['scaffold','vite.config','eslint','socket.io-client','useofficestate',
+                'humanavatar','agentdetailpanel','officecanvas','broadcast','office-layout',
+                'github actions','ci.yml','in-memory','position store','office:join',
+                'websocket.service','office state endpoint']
+    med_kw  = ['speechbubble','lista de usuarios','hacker mode','input de mensagem',
+                'agentavatar','officeroom','socket','playwright','getagentposition']
+    low_kw  = ['tooltip','aria','docs','readme','anti-','role=status']
+    if any(k in t for k in high_kw): return 'high'
+    if any(k in t for k in med_kw):  return 'medium'
+    if any(k in t for k in low_kw):  return 'low'
+    return 'medium'
+
+def infer_size(labels, title):
+    # Labels size:* têm prioridade absoluta
+    for l in labels:
+        if l == 'size:xs': return 'xs'
+        if l == 'size:s':  return 's'
+        if l == 'size:m':  return 'm'
+        if l == 'size:l':  return 'l'
+        if l == 'size:xl': return 'xl'
+    t = title.lower()
+    xs_kw = ['aria','readme','docs:','anti-','click no agent','role=status',
+              'configurar vite','getagentposition','atributos aria','extrair constantes',
+              'tooltip','configurar eslint','ajust','fix typo','renomear',
+              'office:join','office:move','office:leave','get /office']
+    m_kw  = ['officecanvas','officeroom','useofficestate','humanavatar','agentdetailpanel',
+              'agentavatar','office-layout.ts','estado central','conexao com',
+              'playwright','e2e','arrastar','setup playwright','position store',
+              'websocket.service','extend websocket']
+    if any(k in t for k in xs_kw): return 'xs'
+    if any(k in t for k in m_kw):  return 'm'
+    return 's'
+
+def set_field(item_id, field_id, value_id):
+    mutation = ('mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){'
+                'updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,'
+                'fieldId:$f,value:{singleSelectOptionId:$v}}){projectV2Item{id}}}')
+    subprocess.run(
+        ['gh','api','graphql','-f',f'query={mutation}',
+         '-f',f'p={PROJECT_ID}','-f',f'i={item_id}',
+         '-f',f'f={field_id}','-f',f'v={value_id}'],
+        capture_output=True)
+
+updated = 0
+for item in items:
+    c = item.get('content', {})
+    if not c: continue
+    item_id = item['id']
+    num     = c.get('number', '?')
+    title   = c.get('title',  '?')
+    labels  = [l['name'] for l in c.get('labels', {}).get('nodes', [])]
+
+    fvs      = {fv.get('field',{}).get('name'): fv.get('name','—') for fv in item['fieldValues']['nodes'] if fv}
+    priority = fvs.get('Priority', '—')
+    size     = fvs.get('Size',     '—')
+
+    changed = []
+
+    if priority == '—':
+        p = infer_priority(labels, title)
+        set_field(item_id, PRIORITY_FIELD, P[p])
+        changed.append(f'Priority→{p}')
+
+    if size == '—':
+        s = infer_size(labels, title)
+        set_field(item_id, SIZE_FIELD, SZ[s])
+        changed.append(f'Size→{s}')
+
+    if changed:
+        print(f'  #{num:3}  {\" | \".join(changed)}  — {title[:55]}')
+        updated += 1
+
+print(f'\n✅ {updated} itens atualizados')
+if updated == 0:
+    print('Todos os itens já estão com Priority e Size preenchidos.')
+"
+  ;;
+
+# ── sync ──────────────────────────────────────────────────────────────────────
+sync)
+  echo "🔄 Sync: verificando itens fora do board..."
+  echo ""
+
+  # Itens já no board
+  BOARD_NUMS=$(get_items | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+nums = set()
+for item in data['data']['node']['items']['nodes']:
+    c = item.get('content', {})
+    n = c.get('number')
+    if n: nums.add(str(n))
+print(' '.join(sorted(nums, key=int)))
+")
+  echo "Itens no board: $BOARD_NUMS"
+  echo ""
+
+  # Issues abertas não no board
+  echo "── Issues ──────────────────────────────────────────────────"
+  gh issue list --state all --json number,id,title,state --limit 100 | \
+  python3 -c "
+import sys, json, subprocess
+board = set(sys.argv[1].split())
+issues = json.load(sys.stdin)
+PROJECT_ID   = 'PVT_kwHOAPDgbs4BQglq'
+STATUS_FIELD  = 'PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc'
+S_TODO = '532fc3d8'
+S_DONE = 'c841d7a3'
+
+missing = [i for i in issues if str(i['number']) not in board]
+if not missing:
+    print('  ✅ Todas as issues já estão no board')
+else:
+    for i in missing:
+        print(f'  Adicionando #{i[\"number\"]} ({i[\"state\"]}) — {i[\"title\"][:55]}')
+        m = 'mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}'
+        r = subprocess.run(['gh','api','graphql','-f',f'query={m}',
+                            '-f',f'p={PROJECT_ID}','-f',f'c={i[\"id\"]}'],
+                           capture_output=True, text=True)
+        try:
+            item_id = json.loads(r.stdout)['data']['addProjectV2ItemById']['item']['id']
+            status_val = S_DONE if i['state'] == 'CLOSED' else S_TODO
+            m2 = ('mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){'
+                  'updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,'
+                  'fieldId:$f,value:{singleSelectOptionId:$v}}){projectV2Item{id}}}')
+            subprocess.run(['gh','api','graphql','-f',f'query={m2}',
+                            '-f',f'p={PROJECT_ID}','-f',f'i={item_id}',
+                            '-f',f'f={STATUS_FIELD}','-f',f'v={status_val}'],
+                           capture_output=True)
+            label = 'Done' if i['state'] == 'CLOSED' else 'Todo'
+            print(f'    ✅ Adicionado → {label}')
+        except Exception as e:
+            print(f'    ❌ Erro: {e}')
+" -- "$BOARD_NUMS"
+
+  # Discussions
+  echo ""
+  echo "── Discussions ─────────────────────────────────────────────"
+  gh api graphql -f query='
+  {
+    repository(owner:"roxdavirox",name:"mago-office"){
+      discussions(first:30){
+        nodes{ id number title category{name} }
+      }
+    }
+  }' | python3 -c "
+import sys, json, subprocess
+data = json.load(sys.stdin)
+discussions = data['data']['repository']['discussions']['nodes']
+PROJECT_ID  = 'PVT_kwHOAPDgbs4BQglq'
+STATUS_FIELD = 'PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc'
+S_BACKLOG   = '8df12426'
+S_DONE      = 'c841d7a3'
+
+# Discussions resolvidas (decisão tomada)
+resolved = {27, 28, 29}  # Office View → standalone, Hacker Mode → feito, Sprint #1 → passado
+
+for d in discussions:
+    num    = d['number']
+    cat    = d['category']['name']
+    title  = d['title'][:55]
+    print(f'  Discussion #{num} [{cat}] {title}')
+    m = 'mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}'
+    r = subprocess.run(['gh','api','graphql','-f',f'query={m}',
+                        '-f',f'p={PROJECT_ID}','-f',f'c={d[\"id\"]}'],
+                       capture_output=True, text=True)
+    try:
+        result = json.loads(r.stdout)
+        item_id = result['data']['addProjectV2ItemById']['item']['id']
+        status_val = S_DONE if num in resolved else S_BACKLOG
+        label = 'Done' if num in resolved else 'Backlog'
+        m2 = ('mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){'
+              'updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,'
+              'fieldId:$f,value:{singleSelectOptionId:$v}}){projectV2Item{id}}}')
+        subprocess.run(['gh','api','graphql','-f',f'query={m2}',
+                        '-f',f'p={PROJECT_ID}','-f',f'i={item_id}',
+                        '-f',f'f={STATUS_FIELD}','-f',f'v={status_val}'],
+                       capture_output=True)
+        print(f'    ✅ Board → {label}')
+    except Exception as e:
+        print(f'    ⚠️  Discussions não suportadas via API: {e}')
+        if r.stderr:
+            print(f'       {r.stderr[:100]}')
+"
+  echo ""
+  echo "✅ Sync concluído. Execute 'backfill' para preencher Priority+Size."
+  ;;
+
+# ── report ────────────────────────────────────────────────────────────────────
+report)
+  echo ""
+  get_items | python3 -c "
+import sys, json
+from datetime import date
+
+data = json.load(sys.stdin)
+items = data['data']['node']['items']['nodes']
+
+by_status = {}
+for item in items:
+    c = item.get('content', {})
+    if not c: continue
+    num   = c.get('number','?')
+    title = c.get('title','?')
+    fvs   = {fv.get('field',{}).get('name'): fv.get('name','—') for fv in item['fieldValues']['nodes'] if fv}
+    status   = fvs.get('Status','—')
+    priority = fvs.get('Priority','—')
+    size     = fvs.get('Size','—')
+    by_status.setdefault(status,[]).append({'num':num,'title':title,'priority':priority,'size':size})
+
+total = sum(len(v) for v in by_status.values())
+done  = len(by_status.get('Done',[]))
+todo  = len(by_status.get('Todo',[]))
+
+print(f'# 📊 Board Report — mago-office')
+print(f'> Gerado em {date.today()} · Total: {total} itens · Done: {done} · Todo: {todo}')
+print()
+
+order = ['Todo','In Progress','In Review','Backlog','Done','—']
+icons = {'Todo':'📋','In Progress':'🔄','In Review':'👀','Backlog':'🗂️','Done':'✅','—':'❓'}
+
+for s in order:
+    if s not in by_status: continue
+    lst = by_status[s]
+    print(f'## {icons.get(s,\"\")} {s} ({len(lst)})')
+    print()
+    print('| # | Size | Priority | Título |')
+    print('|---|------|----------|--------|')
+    for i in lst:
+        p_flag  = '⚠️' if i['priority'] == '—' else ''
+        sz_flag = '⚠️' if i['size']     == '—' else ''
+        print(f'| #{i[\"num\"]} | {sz_flag}{i[\"size\"]} | {p_flag}{i[\"priority\"]} | {i[\"title\"][:70]} |')
+    print()
+"
+  ;;
+
+# ── discuss ───────────────────────────────────────────────────────────────────
+discuss)
+  echo "💬 Discussions do repositório:"
+  echo ""
+  gh api graphql -f query='
+  {
+    repository(owner:"roxdavirox",name:"mago-office"){
+      discussions(first:30){
+        nodes{
+          number title url
+          category{name}
+          comments{totalCount}
+          isAnswered
+        }
+      }
+    }
+  }' | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for d in data['data']['repository']['discussions']['nodes']:
+    answered = '✅' if d['isAnswered'] else '💬'
+    print(f'  {answered} #{d[\"number\"]} [{d[\"category\"][\"name\"]}] {d[\"title\"]}')
+    print(f'     {d[\"url\"]} ({d[\"comments\"][\"totalCount\"]} comentários)')
+    print()
+"
+  ;;
+
+# ── set ───────────────────────────────────────────────────────────────────────
+set)
+  ISSUE_NUM="${1:?'Uso: mago-board.sh set <N> priority|size|status <valor>'}"
+  FIELD_NAME="${2:?'Campo obrigatório: priority|size|status'}"; FIELD_NAME="${FIELD_NAME,,}"
+  FIELD_VALUE="${3:?'Valor obrigatório'}"; FIELD_VALUE="${FIELD_VALUE,,}"
+
+  # Achar item_id no board pelo número da issue/PR
+  ITEM_ID=$(get_items | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for item in data['data']['node']['items']['nodes']:
+    c = item.get('content',{})
+    if str(c.get('number','')) == '$ISSUE_NUM':
+        print(item['id'])
+        break
+" 2>/dev/null)
+
+  if [ -z "$ITEM_ID" ]; then
+    echo "❌ #$ISSUE_NUM não encontrado no board. Execute 'sync' primeiro."
+    exit 1
+  fi
+
+  case "$FIELD_NAME" in
+    priority)
+      case "$FIELD_VALUE" in
+        urgent) set_field "$ITEM_ID" "$PRIORITY_FIELD" "$P_URGENT" ;;
+        high)   set_field "$ITEM_ID" "$PRIORITY_FIELD" "$P_HIGH"   ;;
+        medium) set_field "$ITEM_ID" "$PRIORITY_FIELD" "$P_MEDIUM" ;;
+        low)    set_field "$ITEM_ID" "$PRIORITY_FIELD" "$P_LOW"    ;;
+        *) echo "Priority: urgent|high|medium|low"; exit 1 ;;
+      esac
+      echo "✅ #$ISSUE_NUM Priority → $FIELD_VALUE"
+      ;;
+    size)
+      case "$FIELD_VALUE" in
+        xs) set_field "$ITEM_ID" "$SIZE_FIELD" "$SZ_XS" ;;
+        s)  set_field "$ITEM_ID" "$SIZE_FIELD" "$SZ_S"  ;;
+        m)  set_field "$ITEM_ID" "$SIZE_FIELD" "$SZ_M"  ;;
+        l)  set_field "$ITEM_ID" "$SIZE_FIELD" "$SZ_L"  ;;
+        xl) set_field "$ITEM_ID" "$SIZE_FIELD" "$SZ_XL" ;;
+        *) echo "Size: xs|s|m|l|xl"; exit 1 ;;
+      esac
+      echo "✅ #$ISSUE_NUM Size → $FIELD_VALUE"
+      # Aplica label de size também na issue
+      gh issue edit "$ISSUE_NUM" --add-label "size:$FIELD_VALUE" 2>/dev/null || true
+      ;;
+    status)
+      case "$FIELD_VALUE" in
+        backlog)      set_field "$ITEM_ID" "$STATUS_FIELD" "$S_BACKLOG"     ;;
+        todo)         set_field "$ITEM_ID" "$STATUS_FIELD" "$S_TODO"        ;;
+        "in progress"|inprogress) set_field "$ITEM_ID" "$STATUS_FIELD" "$S_IN_PROGRESS" ;;
+        "in review"|inreview)     set_field "$ITEM_ID" "$STATUS_FIELD" "$S_IN_REVIEW"   ;;
+        done)         set_field "$ITEM_ID" "$STATUS_FIELD" "$S_DONE"        ;;
+        *) echo "Status: backlog|todo|in progress|in review|done"; exit 1 ;;
+      esac
+      echo "✅ #$ISSUE_NUM Status → $FIELD_VALUE"
+      ;;
+    *)
+      echo "Campo inválido. Use: priority | size | status"
+      exit 1
+      ;;
+  esac
+  ;;
+
+*)
+  echo "Uso: bash scripts/mago-board.sh <subcomando>"
+  echo ""
+  echo "  status              Visão geral por coluna"
+  echo "  backfill            Preencher Priority+Size faltando"
+  echo "  sync                Adicionar issues/discussions faltando"
+  echo "  report              Relatório markdown completo"
+  echo "  discuss             Listar discussions"
+  echo "  set <N> <campo> <v> Atualizar campo (priority|size|status)"
+  echo ""
+  echo "Exemplos:"
+  echo "  bash scripts/mago-board.sh set 47 priority high"
+  echo "  bash scripts/mago-board.sh set 23 size l"
+  exit 1
+  ;;
+
+esac

--- a/scripts/mago-estimate.sh
+++ b/scripts/mago-estimate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# scripts/mago-estimate.sh — Estimativa de issue via rx-architect (MAGO)
+# scripts/mago-estimate.sh — Estimativa de issue via OpenCode
 #
 # Uso: ./scripts/mago-estimate.sh <ISSUE_NUMBER> [--board] [--comment]
 #   --board:   Atualiza campo Size no GitHub Projects board
@@ -24,117 +24,117 @@ if [ -z "$ISSUE_NUMBER" ]; then
   exit 1
 fi
 
-CELEBRO_URL="${CELEBRO_URL:-http://localhost:3099/chat}"
+MODEL="${OPENCODE_MODEL:-opencode/minimax-m2.5-free}"
+OPENCODE="${OPENCODE_BIN:-/home/rx/.opencode/bin/opencode}"
 PROJECT_ID="PVT_kwHOAPDgbs4BQglq"
 SIZE_FIELD_ID="PVTSSF_lAHOAPDgbs4BQglqzg-nNnU"
 SIZE_IDS='{"XS":"c4ee0f78","S":"8a34ec7b","M":"fbe25f78","L":"c15fe1d4","XL":"dcefc6fd"}'
 
+if [ ! -f "$OPENCODE" ]; then
+  echo "Erro: opencode não encontrado em $OPENCODE"
+  exit 1
+fi
+
 # Buscar dados da issue
 ISSUE=$(gh issue view "$ISSUE_NUMBER" --json title,body,labels)
 TITLE=$(echo "$ISSUE" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])")
-BODY=$(echo "$ISSUE"  | python3 -c "import sys,json; print(json.load(sys.stdin)['body'] or '')" | head -c 1000)
+BODY=$(echo "$ISSUE"  | python3 -c "import sys,json; print((json.load(sys.stdin)['body'] or '')[:1500])")
 LABELS=$(echo "$ISSUE" | python3 -c "import sys,json; print(', '.join(l['name'] for l in json.load(sys.stdin)['labels']))")
 
-echo "🏗️  Consultando rx-architect para issue #$ISSUE_NUMBER..."
+echo "📐 Estimando issue #$ISSUE_NUMBER..."
 echo "   $TITLE"
 echo ""
 
-PROMPT="Você é rx-architect do MAGO. Estime esforço e planeje implementação desta issue do projeto mago-office (app React 19 + Vite 6 + TypeScript strict + Framer Motion + socket.io-client — escritório virtual 2D com avatares de agentes IA).
+PROMPT="Estime o esforço desta issue do projeto mago-office (React 19 + Vite + TypeScript + Framer Motion — escritório virtual 2D).
 
-**Issue #$ISSUE_NUMBER: $TITLE**
+Issue #$ISSUE_NUMBER: $TITLE
 Labels: $LABELS
 
 $BODY
 
-Responda EXATAMENTE neste JSON (sem texto fora do JSON):
+Responda SOMENTE em JSON válido, sem texto fora:
 {
-  \"size\": \"XS\" | \"S\" | \"M\" | \"L\" | \"XL\",
-  \"hours\": \"<estimativa ex: 1-2h>\",
-  \"steps\": [
-    {\"order\": 1, \"title\": \"<titulo>\", \"detail\": \"<detalhe tecnico>\"},
-    ...
-  ],
-  \"risks\": [\"<risco se houver>\"],
-  \"dependencies\": [\"<dep se houver>\"]
+  \"size\": \"XS|S|M|L|XL\",
+  \"minutes\": <número inteiro>,
+  \"steps\": [\"passo 1\", \"passo 2\"],
+  \"risks\": [\"risco se houver\"],
+  \"split\": [\"sub-issue se L ou XL\"]
 }
 
-Critérios de size:
-- XS: 1-2h trivial
-- S: meio dia pequeno
-- M: 1 dia medio
-- L: 2-3 dias grande
-- XL: semana+ (sugerir quebrar)"
+Critérios (issues devem caber em até 30 min):
+- XS: <10min — 1 arquivo, mudança trivial
+- S:  ~15min — 1-2 arquivos, adição pequena
+- M:  ~30min — 2-4 arquivos, feature completa pequena (máximo aceitável)
+- L:  >30min — QUEBRAR antes. Liste sub-issues em \"split\"
+- XL: nunca aceitar — sempre quebrar"
 
 TMPFILE=$(mktemp)
 printf '%s' "$PROMPT" > "$TMPFILE"
-PAYLOAD=$(python3 -c "
-import json, sys
-text = open(sys.argv[1]).read()
-print(json.dumps({'text': text, 'agent': 'rx-architect'}))
-" "$TMPFILE")
+
+RAW=$(timeout 60 "$OPENCODE" run -m "$MODEL" "$(cat "$TMPFILE")" 2>&1 \
+  | sed 's/\x1b\[[0-9;]*[A-Za-z]//g')
 rm -f "$TMPFILE"
 
-RESPONSE=$(curl -s --max-time 30 -X POST "$CELEBRO_URL" \
-  -H "Content-Type: application/json" \
-  -d "$PAYLOAD" \
-  | python3 -c "import sys,json; print(json.load(sys.stdin).get('response',''))")
-
-# Extrair JSON da resposta
-PLAN=$(echo "$RESPONSE" | python3 -c "
+PLAN=$(echo "$RAW" | python3 -c "
 import sys, json, re
 text = sys.stdin.read()
 match = re.search(r'\{[\s\S]*\}', text)
 if match:
     try:
         print(json.dumps(json.loads(match.group(0)), indent=2, ensure_ascii=False))
-    except:
+    except Exception:
         print(text)
 else:
     print(text)
 ")
 
-SIZE=$(echo "$PLAN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('size','M'))" 2>/dev/null || echo "M")
-HOURS=$(echo "$PLAN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hours','?'))" 2>/dev/null || echo "?")
+SIZE=$(echo "$PLAN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('size','S').upper())" 2>/dev/null || echo "S")
+MINS=$(echo "$PLAN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('minutes','?'))" 2>/dev/null || echo "?")
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "📐 Estimativa rx-architect"
-echo "   Size: $SIZE ($HOURS)"
+echo "Size: $SIZE (~${MINS}min)  [máx 30min]"
 echo ""
 echo "$PLAN" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
     for s in d.get('steps', []):
-        print(f\"  {s['order']}. {s['title']}\")
-        print(f\"     {s['detail']}\")
-        print()
+        print(f'  • {s}')
     risks = d.get('risks', [])
     if risks:
-        print('  ⚠️  Riscos:', ', '.join(risks))
-    deps = d.get('dependencies', [])
-    if deps:
-        print('  🔗 Deps:', ', '.join(deps))
-except:
+        print()
+        print('  Riscos:', ', '.join(risks))
+    split = d.get('split', [])
+    if split:
+        print()
+        print('  ⚠️  L/XL — quebrar em:')
+        for s in split:
+            print(f'    - {s}')
+except Exception:
     print(sys.stdin.read())
 " 2>/dev/null || echo "$PLAN"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # Atualizar campo Size no board
 if [ -n "$UPDATE_BOARD" ]; then
-  SIZE_OPTION=$(echo "$SIZE_IDS" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$SIZE', d['M']))")
-  ISSUE_NODE=$(gh api "repos/$(gh repo view --json nameWithOwner --jq '.nameWithOwner')/issues/$ISSUE_NUMBER" --jq '.node_id')
+  SIZE_OPTION=$(echo "$SIZE_IDS" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); print(d.get('$SIZE', d['S']))")
+  ISSUE_NODE=$(gh api "repos/roxdavirox/mago-office/issues/$ISSUE_NUMBER" --jq '.node_id')
   ITEM_ID=$(gh api graphql -f query='
     mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}
   ' -f p="$PROJECT_ID" -f c="$ISSUE_NODE" --jq '.data.addProjectV2ItemById.item.id')
 
   gh api graphql -f query='
     mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){
-      updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$v}}){
-        projectV2Item{id}
-      }
+      updateProjectV2ItemFieldValue(input:{
+        projectId:$p itemId:$i fieldId:$f value:{singleSelectOptionId:$v}
+      }){projectV2Item{id}}
     }
   ' -f p="$PROJECT_ID" -f i="$ITEM_ID" -f f="$SIZE_FIELD_ID" -f v="$SIZE_OPTION" > /dev/null
-  echo "✅ Board atualizado: Size=$SIZE para issue #$ISSUE_NUMBER"
+  # Aplicar label de size na issue também
+  SIZE_LOWER=$(echo "$SIZE" | tr '[:upper:]' '[:lower:]')
+  gh issue edit "$ISSUE_NUMBER" --add-label "size:$SIZE_LOWER" 2>/dev/null || true
+  echo "✅ Board: Size=$SIZE na issue #$ISSUE_NUMBER"
 fi
 
 # Postar plano como comentário na issue
@@ -143,37 +143,29 @@ if [ -n "$POST_COMMENT" ]; then
 import sys, json
 try:
     d = json.load(sys.stdin)
-    size = d.get('size','?')
-    hours = d.get('hours','?')
+    size  = d.get('size','?')
+    mins  = d.get('minutes','?')
     steps = d.get('steps', [])
     risks = d.get('risks', [])
-    deps = d.get('dependencies', [])
-
+    split = d.get('split', [])
     lines = [
-        '## 🏗️ Plano rx-architect',
+        '## 📐 Estimativa',
+        f'**Size:** \`{size}\` (~{mins}min)',
         '',
-        f'**Size:** \`{size}\` ({hours})',
-        '',
-        '### Passos',
+        '**Passos:**',
     ]
     for s in steps:
-        lines.append(f\"{s['order']}. **{s['title']}**\")
-        lines.append(f\"   {s['detail']}\")
+        lines.append(f'- {s}')
+    if split:
+        lines.append('')
+        lines.append('**⚠️ Issue grande — quebrar em:**')
+        for s in split:
+            lines.append(f'- {s}')
     if risks:
         lines.append('')
-        lines.append('### Riscos')
-        for r in risks:
-            lines.append(f'- ⚠️ {r}')
-    if deps:
-        lines.append('')
-        lines.append('### Dependências')
-        for dep in deps:
-            lines.append(f'- 🔗 {dep}')
-    lines.append('')
-    lines.append('---')
-    lines.append('*Estimativa automática via rx-architect (MAGO)*')
+        lines.append('**Riscos:** ' + ', '.join(risks))
     print('\n'.join(lines))
-except Exception as e:
+except Exception:
     print(sys.stdin.read())
 ")
   gh issue comment "$ISSUE_NUMBER" --body "$COMMENT"

--- a/scripts/mago-sprint.sh
+++ b/scripts/mago-sprint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# scripts/mago-sprint.sh — Planejamento de sprint via rx-orchestrator (MAGO)
+# scripts/mago-sprint.sh — Planejamento de sprint via OpenCode
 #
 # Uso: ./scripts/mago-sprint.sh [--post]
-#   --post: Posta plano como discussion ou issue no repo
+#   --post: Cria issue de sprint no repo com o plano
 
 set -e
 
@@ -14,12 +14,18 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-CELEBRO_URL="${CELEBRO_URL:-http://localhost:3099/chat}"
+MODEL="${OPENCODE_MODEL:-opencode/minimax-m2.5-free}"
+OPENCODE="${OPENCODE_BIN:-/home/rx/.opencode/bin/opencode}"
 
-echo "🎯 Consultando rx-orchestrator para planejamento de sprint..."
+if [ ! -f "$OPENCODE" ]; then
+  echo "Erro: opencode não encontrado em $OPENCODE"
+  exit 1
+fi
+
+echo "🎯 Planejando sprint..."
 echo ""
 
-# Coletar issues abertas com campos do board
+# Coletar issues abertas com priority e size labels
 OPEN_ISSUES=$(gh issue list --state open --json number,title,labels --limit 30 \
   | python3 -c "
 import sys, json
@@ -28,8 +34,9 @@ lines = []
 for i in issues:
     labels = [l['name'] for l in i['labels']]
     priority = next((l for l in labels if l.startswith('priority:')), 'priority:medium')
-    kind = next((l for l in labels if l not in ['feature','frontend','backend','ui','animation','test','chore'] and not l.startswith('priority:')), '')
-    lines.append(f\"#{i['number']} [{priority}] {i['title']}\")
+    size = next((l for l in labels if l.startswith('size:')), '')
+    entry = f\"#{i['number']} [{priority}]{' [' + size + ']' if size else ''} {i['title']}\"
+    lines.append(entry)
 print('\n'.join(lines))
 ")
 
@@ -37,137 +44,100 @@ echo "Issues abertas:"
 echo "$OPEN_ISSUES"
 echo ""
 
-# Montar request e chamar Celebro via Python (evita problemas de escaping no shell)
-RESPONSE=$(python3 - "$CELEBRO_URL" <<PYEOF
-import sys, json, urllib.request
+PROMPT="Planeje o próximo sprint do projeto mago-office (React 19 + Vite + TypeScript — escritório virtual 2D).
 
-celebro_url = sys.argv[1]
-open_issues = """$OPEN_ISSUES"""
-
-prompt = f"""Você é rx-orchestrator do MAGO. Planeje o próximo sprint (2 semanas) para o projeto mago-office.
-
-Contexto: App React 19 + Framer Motion — escritório virtual 2D com avatares de agentes IA.
+REGRA: cada issue cabe em no máximo 30min. Sprint = sessão de ~2h (4-6 issues XS/S/M).
 
 Issues abertas:
-{open_issues}
+$OPEN_ISSUES
 
-Critérios: priority:high primeiro, dependências técnicas antes de feat, equilibrar feat/test/chore, sprint realista 1 dev 80h.
+Sizes: XS<10min | S~15min | M~30min(máx) | L/XL=quebrar antes
 
-Responda EXATAMENTE neste JSON (sem texto fora do JSON):
-{{
-  "sprint_goal": "<objetivo em 1 frase>",
-  "capacity": "<estimativa total>",
-  "selected": [{{"issue": 0, "priority": "alta|media|baixa", "reason": "<justificativa>", "size": "XS|S|M|L|XL"}}],
-  "deferred": [{{"issue": 0, "reason": "<motivo>"}}],
-  "risks": ["<risco>"]
-}}"""
+Selecione 4-6 issues priorizando: priority:high > medium > low.
+Se uma issue for grande demais, indique para quebrar.
 
-payload = json.dumps({{"text": prompt, "agent": "rx-orchestrator"}}).encode()
-req = urllib.request.Request(celebro_url, data=payload,
-      headers={{"Content-Type": "application/json"}})
-try:
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        data = json.loads(resp.read())
-        print(data.get("response", ""))
-except Exception as e:
-    print(f"ERRO: {{e}}", file=sys.stderr)
-PYEOF
-)
+Responda SOMENTE em JSON válido:
+{
+  \"goal\": \"objetivo do sprint em 1 frase\",
+  \"capacity\": \"~2h, N issues\",
+  \"selected\": [{\"issue\": 0, \"reason\": \"motivo curto\"}],
+  \"defer\": [{\"issue\": 0, \"reason\": \"motivo ou quebrar\"}]
+}"
 
-PLAN=$(echo "$RESPONSE" | python3 -c "
+TMPFILE=$(mktemp)
+printf '%s' "$PROMPT" > "$TMPFILE"
+
+RAW=$(timeout 60 "$OPENCODE" run -m "$MODEL" "$(cat "$TMPFILE")" 2>&1 \
+  | sed 's/\x1b\[[0-9;]*[A-Za-z]//g')
+rm -f "$TMPFILE"
+
+PLAN=$(echo "$RAW" | python3 -c "
 import sys, json, re
 text = sys.stdin.read()
 match = re.search(r'\{[\s\S]*\}', text)
 if match:
     try:
         print(json.dumps(json.loads(match.group(0)), indent=2, ensure_ascii=False))
-    except:
+    except Exception:
         print(text)
 else:
     print(text)
 ")
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "🎯 Plano rx-orchestrator"
-echo ""
 echo "$PLAN" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
-    print(f\"Sprint Goal: {d.get('sprint_goal','?')}\")
+    print(f\"Goal: {d.get('goal','?')}\")
     print(f\"Capacidade: {d.get('capacity','?')}\")
     print()
     print('✅ Selecionadas:')
     for s in d.get('selected', []):
-        print(f\"  #{s['issue']} [{s['size']}] {s['priority'].upper()} — {s['reason']}\")
-    deferred = d.get('deferred', [])
-    if deferred:
+        print(f\"  #{s['issue']} — {s['reason']}\")
+    defer = d.get('defer', [])
+    if defer:
         print()
-        print('⏭️  Adiadas:')
-        for s in deferred:
+        print('⏭  Adiadas:')
+        for s in defer:
             print(f\"  #{s['issue']} — {s['reason']}\")
-    risks = d.get('risks', [])
-    if risks:
-        print()
-        print('⚠️  Riscos:')
-        for r in risks:
-            print(f'  - {r}')
-except:
+except Exception:
     print(sys.stdin.read())
 " 2>/dev/null || echo "$PLAN"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-# Postar como issue de sprint no repo
 if [ -n "$POST_COMMENT" ]; then
-  SPRINT_BODY=$(echo "$PLAN" | python3 -c "
+  BODY=$(echo "$PLAN" | python3 -c "
 import sys, json
 from datetime import date, timedelta
 try:
     d = json.load(sys.stdin)
     today = date.today()
-    end = today + timedelta(days=14)
-    goal = d.get('sprint_goal','?')
-    capacity = d.get('capacity','?')
-    selected = d.get('selected', [])
-    deferred = d.get('deferred', [])
-    risks = d.get('risks', [])
-
+    end   = today + timedelta(days=14)
     lines = [
         f'## Sprint {today} → {end}',
+        f'**Goal:** {d.get(\"goal\",\"?\")}',
+        f'**Capacidade:** {d.get(\"capacity\",\"?\")}',
         '',
-        f'**Goal:** {goal}',
-        f'**Capacidade:** {capacity}',
-        '',
-        '## Issues do Sprint',
-        '',
-        '| Issue | Size | Prioridade | Justificativa |',
-        '|-------|------|------------|---------------|',
+        '## Issues',
+        '| # | Motivo |',
+        '|---|--------|',
     ]
-    for s in selected:
-        lines.append(f\"| #{s['issue']} | {s['size']} | {s['priority']} | {s['reason']} |\")
-    if deferred:
+    for s in d.get('selected', []):
+        lines.append(f'| #{s[\"issue\"]} | {s[\"reason\"]} |')
+    defer = d.get('defer', [])
+    if defer:
         lines.append('')
         lines.append('## Adiadas')
-        for s in deferred:
-            lines.append(f\"- #{s['issue']}: {s['reason']}\")
-    if risks:
-        lines.append('')
-        lines.append('## Riscos do Sprint')
-        for r in risks:
-            lines.append(f'- ⚠️ {r}')
-    lines.append('')
-    lines.append('---')
-    lines.append('*Planejamento automático via rx-orchestrator (MAGO)*')
+        for s in defer:
+            lines.append(f'- #{s[\"issue\"]}: {s[\"reason\"]}')
     print('\n'.join(lines))
-except Exception as e:
-    print(f'Erro ao formatar: {e}')
+except Exception:
     print(sys.stdin.read())
 ")
-
-  SPRINT_TITLE="chore(sprint): planejamento $(date +%Y-%m-%d)"
   gh issue create \
-    --title "$SPRINT_TITLE" \
-    --body "$SPRINT_BODY" \
+    --title "chore(sprint): planejamento $(date +%Y-%m-%d)" \
+    --body "$BODY" \
     --label "chore" \
     && echo "✅ Issue de sprint criada!"
 fi

--- a/scripts/pr-create.sh
+++ b/scripts/pr-create.sh
@@ -22,18 +22,22 @@ fi
 
 echo "==> Buscando dados da issue #$ISSUE..."
 
-ISSUE_LABELS=$(gh issue view "$ISSUE" --repo roxdavirox/mago-office --json labels -q '.labels[].name' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-MILESTONE=$(gh issue view "$ISSUE" --repo roxdavirox/mago-office --json milestone -q '.milestone.title' 2>/dev/null || echo "")
-ISSUE_BODY=$(gh issue view "$ISSUE" --repo roxdavirox/mago-office --json body -q '.body' 2>/dev/null || echo "")
+ISSUE_LABELS=$(gh issue view "$ISSUE" --repo roxdavirox/mago-office --json labels \
+  -q '.labels[].name' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+MILESTONE=$(gh issue view "$ISSUE" --repo roxdavirox/mago-office --json milestone \
+  -q '.milestone.title' 2>/dev/null || echo "")
+ISSUE_BODY=$(gh issue view "$ISSUE" --repo roxdavirox/mago-office --json body \
+  -q '.body' 2>/dev/null || echo "")
 
 TYPE=$(echo "$BRANCH" | cut -d'/' -f1)
 case $TYPE in
-  feat)  EXTRA_LABELS="enhancement" ;;
-  fix)   EXTRA_LABELS="bug" ;;
-  test)  EXTRA_LABELS="test" ;;
-  chore) EXTRA_LABELS="dx" ;;
-  ci)    EXTRA_LABELS="ci" ;;
-  *)     EXTRA_LABELS="" ;;
+  feat)    EXTRA_LABELS="enhancement" ;;
+  fix)     EXTRA_LABELS="bug"         ;;
+  test)    EXTRA_LABELS="test"        ;;
+  chore)   EXTRA_LABELS="dx"          ;;
+  ci)      EXTRA_LABELS="ci"          ;;
+  refactor) EXTRA_LABELS="chore"      ;;
+  *)       EXTRA_LABELS=""            ;;
 esac
 
 if [[ -n "$ISSUE_LABELS" && -n "$EXTRA_LABELS" ]]; then
@@ -44,7 +48,12 @@ else
   LABELS="$EXTRA_LABELS"
 fi
 
-TITLE=$(git log -1 --format=%s)
+# Título: pegar do último commit da branch (excluindo commits de develop)
+TITLE=$(git log develop..HEAD --format=%s | head -1)
+if [[ -z "$TITLE" ]]; then
+  # Fallback: título da issue
+  TITLE=$(gh issue view "$ISSUE" --repo roxdavirox/mago-office --json title -q .title 2>/dev/null || echo "")
+fi
 
 if ! git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
   echo "==> Push da branch..."
@@ -68,11 +77,12 @@ echo "  Milestone: ${MILESTONE:-nenhum}"
 echo "  Issue:     #$ISSUE"
 echo ""
 
-ARGS="--title \"$TITLE\" --body \"$PR_BODY\" --base develop"
-[[ -n "$LABELS" ]] && ARGS="$ARGS --label \"$LABELS\""
-[[ -n "$MILESTONE" ]] && ARGS="$ARGS --milestone \"$MILESTONE\""
+# Usar array para evitar problemas de escaping com eval
+CMD=(gh pr create --title "$TITLE" --body "$PR_BODY" --base develop)
+[[ -n "$LABELS" ]]    && CMD+=(--label "$LABELS")
+[[ -n "$MILESTONE" ]] && CMD+=(--milestone "$MILESTONE")
 
-eval "gh pr create $ARGS"
+"${CMD[@]}"
 
 echo ""
 echo "==> PR criada!"


### PR DESCRIPTION
Revisão completa do workflow integrado.

## O que foi corrigido

- **pr-create**: removido `eval` com risco de injection, substituído por array bash
- **branch-create**: fix no check do Celebro (estava sempre `true`), atualiza board para In Progress ao criar branch, suporte a tipos `refactor` e `docs`
- **mago-estimate + mago-sprint**: removido Celebro (contexto errado), substituído por OpenCode — consistente com `pr-review.sh`
- **mago-board**: novo script de gerenciamento completo do board (`status`, `backfill`, `sync`, `report`, `set`)
- **deploy**: `deploy.yml` agora chama `deploy.sh` (carrega NVM corretamente), adicionada verificação de `dist/index.html`
- **project-automation**: evento `labeled` (Priority/Size), evento `discussion`, fallback de token sem GITHUB_TOKEN (sem scope project)

## Board
- 51 itens agora com Priority + Size preenchidos
- Issues `#1-#4, #30, #33` adicionadas e preenchidas via backfill