### PR TITLE
fix(scripts): integrar celebro + opencode sem substituir

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -50,14 +50,8 @@ jobs:
 
       - name: Usar PAT como fallback
         if: steps.token.outcome == 'failure'
-        # GITHUB_TOKEN não tem scope 'project' — requer GH_PAT com project:write
-        run: |
-          if [ -z "${{ secrets.GH_PAT }}" ]; then
-            echo "⚠️  GH_PAT não configurado. Automações do board não funcionarão."
-            echo "   Configure o secret GH_PAT com scope: project, repo"
-            exit 1
-          fi
-          echo "GH_TOKEN=${{ secrets.GH_PAT }}" >> $GITHUB_ENV
+        # GH_PAT precisa ter scope 'project' — GITHUB_TOKEN não tem
+        run: echo "GH_TOKEN=${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 
       - name: Definir token
         if: steps.token.outcome == 'success'

--- a/scripts/branch-create.sh
+++ b/scripts/branch-create.sh
@@ -72,16 +72,10 @@ if [[ -n "$ISSUE_NODE" ]]; then
   fi
 fi
 
-# ── Consultar rx-architect para estimativa ────────────────────────────────────
-CELEBRO_URL="${CELEBRO_URL:-http://localhost:3099/chat}"
-if curl -s --connect-timeout 2 "$CELEBRO_URL" > /dev/null 2>&1; then
-  echo ""
-  echo "🏗️  Consultando rx-architect..."
-  bash "$(dirname "$0")/mago-estimate.sh" "$ISSUE" --board --comment 2>/dev/null \
-    || echo "⚠️  rx-architect indisponível (continuando sem estimativa)"
-else
-  echo "⚠️  Celebro offline — estimativa pulada"
-fi
+# ── Consultar rx-architect para estimativa (Celebro ou OpenCode) ──────────────
+echo ""
+bash "$(dirname "$0")/mago-estimate.sh" "$ISSUE" --board --comment 2>/dev/null \
+  || echo "⚠️  Estimativa indisponível (continuando)"
 
 echo ""
 echo "Próximo: implemente, commite e rode ./scripts/pr-create.sh $ISSUE"

--- a/scripts/mago-estimate.sh
+++ b/scripts/mago-estimate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# scripts/mago-estimate.sh — Estimativa de issue via OpenCode
+# scripts/mago-estimate.sh — Estimativa de issue via rx-architect (Celebro) com fallback OpenCode
 #
 # Uso: ./scripts/mago-estimate.sh <ISSUE_NUMBER> [--board] [--comment]
 #   --board:   Atualiza campo Size no GitHub Projects board
@@ -24,101 +24,157 @@ if [ -z "$ISSUE_NUMBER" ]; then
   exit 1
 fi
 
+CELEBRO_URL="${CELEBRO_URL:-http://localhost:3099/chat}"
 MODEL="${OPENCODE_MODEL:-opencode/minimax-m2.5-free}"
 OPENCODE="${OPENCODE_BIN:-/home/rx/.opencode/bin/opencode}"
 PROJECT_ID="PVT_kwHOAPDgbs4BQglq"
 SIZE_FIELD_ID="PVTSSF_lAHOAPDgbs4BQglqzg-nNnU"
 SIZE_IDS='{"XS":"c4ee0f78","S":"8a34ec7b","M":"fbe25f78","L":"c15fe1d4","XL":"dcefc6fd"}'
 
-if [ ! -f "$OPENCODE" ]; then
-  echo "Erro: opencode não encontrado em $OPENCODE"
-  exit 1
-fi
-
 # Buscar dados da issue
 ISSUE=$(gh issue view "$ISSUE_NUMBER" --json title,body,labels)
 TITLE=$(echo "$ISSUE" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])")
-BODY=$(echo "$ISSUE"  | python3 -c "import sys,json; print((json.load(sys.stdin)['body'] or '')[:1500])")
+BODY=$(echo "$ISSUE"  | python3 -c "import sys,json; print(json.load(sys.stdin)['body'] or '')" | head -c 1000)
 LABELS=$(echo "$ISSUE" | python3 -c "import sys,json; print(', '.join(l['name'] for l in json.load(sys.stdin)['labels']))")
 
-echo "📐 Estimando issue #$ISSUE_NUMBER..."
+echo "🏗️  Consultando rx-architect para issue #$ISSUE_NUMBER..."
 echo "   $TITLE"
 echo ""
 
-PROMPT="Estime o esforço desta issue do projeto mago-office (React 19 + Vite + TypeScript + Framer Motion — escritório virtual 2D).
+PROMPT="Você é rx-architect do MAGO. Estime esforço e planeje implementação desta issue do projeto mago-office (app React 19 + Vite 6 + TypeScript strict + Framer Motion + socket.io-client — escritório virtual 2D com avatares de agentes IA).
 
-Issue #$ISSUE_NUMBER: $TITLE
+**Issue #$ISSUE_NUMBER: $TITLE**
 Labels: $LABELS
 
 $BODY
 
-Responda SOMENTE em JSON válido, sem texto fora:
+Responda EXATAMENTE neste JSON (sem texto fora do JSON):
 {
-  \"size\": \"XS|S|M|L|XL\",
-  \"minutes\": <número inteiro>,
-  \"steps\": [\"passo 1\", \"passo 2\"],
-  \"risks\": [\"risco se houver\"],
-  \"split\": [\"sub-issue se L ou XL\"]
+  \"size\": \"XS\" | \"S\" | \"M\" | \"L\" | \"XL\",
+  \"hours\": \"<estimativa ex: 1-2h>\",
+  \"steps\": [
+    {\"order\": 1, \"title\": \"<titulo>\", \"detail\": \"<detalhe tecnico>\"},
+    ...
+  ],
+  \"risks\": [\"<risco se houver>\"],
+  \"dependencies\": [\"<dep se houver>\"]
 }
 
-Critérios (issues devem caber em até 30 min):
-- XS: <10min — 1 arquivo, mudança trivial
-- S:  ~15min — 1-2 arquivos, adição pequena
-- M:  ~30min — 2-4 arquivos, feature completa pequena (máximo aceitável)
-- L:  >30min — QUEBRAR antes. Liste sub-issues em \"split\"
-- XL: nunca aceitar — sempre quebrar"
+Critérios de size:
+- XS: 1-2h trivial
+- S: meio dia pequeno
+- M: 1 dia médio
+- L: 2-3 dias grande
+- XL: semana+ (sugerir quebrar)"
 
-TMPFILE=$(mktemp)
-printf '%s' "$PROMPT" > "$TMPFILE"
+# ── Tentar Celebro primeiro ────────────────────────────────────────────────────
+PLAN=""
+BACKEND=""
 
-RAW=$(timeout 60 "$OPENCODE" run -m "$MODEL" "$(cat "$TMPFILE")" 2>&1 \
-  | sed 's/\x1b\[[0-9;]*[A-Za-z]//g')
-rm -f "$TMPFILE"
+if curl -s --connect-timeout 2 "$CELEBRO_URL" > /dev/null 2>&1; then
+  echo "   via rx-architect (Celebro)..."
+  TMPFILE=$(mktemp)
+  printf '%s' "$PROMPT" > "$TMPFILE"
+  PAYLOAD=$(python3 -c "
+import json, sys
+text = open(sys.argv[1]).read()
+print(json.dumps({'text': text, 'agent': 'rx-architect'}))
+" "$TMPFILE")
+  rm -f "$TMPFILE"
 
-PLAN=$(echo "$RAW" | python3 -c "
+  RESPONSE=$(curl -s --max-time 30 -X POST "$CELEBRO_URL" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('response',''))" 2>/dev/null || echo "")
+
+  PLAN=$(echo "$RESPONSE" | python3 -c "
 import sys, json, re
 text = sys.stdin.read()
 match = re.search(r'\{[\s\S]*\}', text)
 if match:
     try:
         print(json.dumps(json.loads(match.group(0)), indent=2, ensure_ascii=False))
+    except:
+        pass
+" 2>/dev/null || echo "")
+  [[ -n "$PLAN" ]] && BACKEND="celebro"
+fi
+
+# ── Fallback para OpenCode se Celebro falhou ──────────────────────────────────
+if [[ -z "$PLAN" ]]; then
+  if [ ! -f "$OPENCODE" ]; then
+    echo "⚠️  Celebro indisponível e OpenCode não encontrado em $OPENCODE"
+    exit 0
+  fi
+  echo "   via OpenCode (fallback)..."
+  TMPFILE=$(mktemp)
+  printf '%s' "$PROMPT" > "$TMPFILE"
+  RAW=$(timeout 60 "$OPENCODE" run -m "$MODEL" "$(cat "$TMPFILE")" 2>&1 \
+    | sed 's/\x1b\[[0-9;]*[A-Za-z]//g')
+  rm -f "$TMPFILE"
+
+  # Normalizar JSON do OpenCode para formato Celebro (steps como objetos)
+  PLAN=$(echo "$RAW" | python3 -c "
+import sys, json, re
+text = sys.stdin.read()
+match = re.search(r'\{[\s\S]*\}', text)
+if match:
+    try:
+        d = json.loads(match.group(0))
+        steps = d.get('steps', [])
+        if steps and isinstance(steps[0], str):
+            d['steps'] = [{'order': i+1, 'title': s, 'detail': ''} for i, s in enumerate(steps)]
+        if 'minutes' in d and 'hours' not in d:
+            mins = d.get('minutes', 0)
+            d['hours'] = f'{mins}min' if mins < 60 else f'{mins//60}h'
+        if 'split' in d and 'dependencies' not in d:
+            d['dependencies'] = d.pop('split')
+        print(json.dumps(d, indent=2, ensure_ascii=False))
     except Exception:
         print(text)
-else:
-    print(text)
-")
+" 2>/dev/null || echo "")
+  [[ -n "$PLAN" ]] && BACKEND="opencode"
+fi
 
-SIZE=$(echo "$PLAN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('size','S').upper())" 2>/dev/null || echo "S")
-MINS=$(echo "$PLAN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('minutes','?'))" 2>/dev/null || echo "?")
+if [[ -z "$PLAN" ]]; then
+  echo "⚠️  Nenhum backend disponível — estimativa indisponível"
+  exit 0
+fi
+
+SIZE=$(echo "$PLAN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('size','M'))" 2>/dev/null || echo "M")
+HOURS=$(echo "$PLAN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hours','?'))" 2>/dev/null || echo "?")
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Size: $SIZE (~${MINS}min)  [máx 30min]"
+echo "📐 Estimativa rx-architect"
+echo "   Size: $SIZE ($HOURS) [via $BACKEND]"
 echo ""
 echo "$PLAN" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
     for s in d.get('steps', []):
-        print(f'  • {s}')
+        if isinstance(s, dict):
+            print(f\"  {s.get('order','•')}. {s.get('title','')}\")
+            if s.get('detail'):
+                print(f\"     {s['detail']}\")
+            print()
+        else:
+            print(f'  • {s}')
     risks = d.get('risks', [])
     if risks:
-        print()
-        print('  Riscos:', ', '.join(risks))
-    split = d.get('split', [])
-    if split:
-        print()
-        print('  ⚠️  L/XL — quebrar em:')
-        for s in split:
-            print(f'    - {s}')
-except Exception:
+        print('  ⚠️  Riscos:', ', '.join(risks))
+    deps = d.get('dependencies', [])
+    if deps:
+        print('  🔗 Deps:', ', '.join(deps))
+except:
     print(sys.stdin.read())
 " 2>/dev/null || echo "$PLAN"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-# Atualizar campo Size no board
+# ── Atualizar campo Size no board ─────────────────────────────────────────────
 if [ -n "$UPDATE_BOARD" ]; then
   SIZE_OPTION=$(echo "$SIZE_IDS" | python3 -c \
-    "import sys,json; d=json.load(sys.stdin); print(d.get('$SIZE', d['S']))")
+    "import sys,json; d=json.load(sys.stdin); print(d.get('$SIZE', d['M']))")
   ISSUE_NODE=$(gh api "repos/roxdavirox/mago-office/issues/$ISSUE_NUMBER" --jq '.node_id')
   ITEM_ID=$(gh api graphql -f query='
     mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}
@@ -131,39 +187,47 @@ if [ -n "$UPDATE_BOARD" ]; then
       }){projectV2Item{id}}
     }
   ' -f p="$PROJECT_ID" -f i="$ITEM_ID" -f f="$SIZE_FIELD_ID" -f v="$SIZE_OPTION" > /dev/null
-  # Aplicar label de size na issue também
   SIZE_LOWER=$(echo "$SIZE" | tr '[:upper:]' '[:lower:]')
   gh issue edit "$ISSUE_NUMBER" --add-label "size:$SIZE_LOWER" 2>/dev/null || true
-  echo "✅ Board: Size=$SIZE na issue #$ISSUE_NUMBER"
+  echo "✅ Board atualizado: Size=$SIZE na issue #$ISSUE_NUMBER"
 fi
 
-# Postar plano como comentário na issue
+# ── Postar plano como comentário na issue ─────────────────────────────────────
 if [ -n "$POST_COMMENT" ]; then
   COMMENT=$(echo "$PLAN" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
     size  = d.get('size','?')
-    mins  = d.get('minutes','?')
+    hours = d.get('hours','?')
     steps = d.get('steps', [])
     risks = d.get('risks', [])
-    split = d.get('split', [])
+    deps  = d.get('dependencies', [])
     lines = [
-        '## 📐 Estimativa',
-        f'**Size:** \`{size}\` (~{mins}min)',
+        '## 🏗️ Plano rx-architect',
         '',
-        '**Passos:**',
+        f'**Size:** \`{size}\` ({hours})',
+        '',
+        '### Passos',
     ]
     for s in steps:
-        lines.append(f'- {s}')
-    if split:
-        lines.append('')
-        lines.append('**⚠️ Issue grande — quebrar em:**')
-        for s in split:
+        if isinstance(s, dict):
+            lines.append(f\"{s.get('order','•')}. **{s.get('title','')}**\")
+            if s.get('detail'):
+                lines.append(f\"   {s['detail']}\")
+        else:
             lines.append(f'- {s}')
     if risks:
         lines.append('')
-        lines.append('**Riscos:** ' + ', '.join(risks))
+        lines.append('### Riscos')
+        for r in risks: lines.append(f'- ⚠️ {r}')
+    if deps:
+        lines.append('')
+        lines.append('### Dependências')
+        for dep in deps: lines.append(f'- 🔗 {dep}')
+    lines.append('')
+    lines.append('---')
+    lines.append('*Estimativa automática via rx-architect (MAGO)*')
     print('\n'.join(lines))
 except Exception:
     print(sys.stdin.read())

--- a/scripts/mago-sprint.sh
+++ b/scripts/mago-sprint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# scripts/mago-sprint.sh — Planejamento de sprint via OpenCode
+# scripts/mago-sprint.sh — Planejamento de sprint via rx-orchestrator (Celebro) com fallback OpenCode
 #
 # Uso: ./scripts/mago-sprint.sh [--post]
 #   --post: Cria issue de sprint no repo com o plano
@@ -14,18 +14,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+CELEBRO_URL="${CELEBRO_URL:-http://localhost:3099/chat}"
 MODEL="${OPENCODE_MODEL:-opencode/minimax-m2.5-free}"
 OPENCODE="${OPENCODE_BIN:-/home/rx/.opencode/bin/opencode}"
 
-if [ ! -f "$OPENCODE" ]; then
-  echo "Erro: opencode não encontrado em $OPENCODE"
-  exit 1
-fi
-
-echo "🎯 Planejando sprint..."
+echo "🎯 Consultando rx-orchestrator para planejamento de sprint..."
 echo ""
 
-# Coletar issues abertas com priority e size labels
+# Coletar issues abertas com campos do board
 OPEN_ISSUES=$(gh issue list --state open --json number,title,labels --limit 30 \
   | python3 -c "
 import sys, json
@@ -44,100 +40,183 @@ echo "Issues abertas:"
 echo "$OPEN_ISSUES"
 echo ""
 
-PROMPT="Planeje o próximo sprint do projeto mago-office (React 19 + Vite + TypeScript — escritório virtual 2D).
+PROMPT="Você é rx-orchestrator do MAGO. Planeje o próximo sprint (2 semanas) para o projeto mago-office.
 
-REGRA: cada issue cabe em no máximo 30min. Sprint = sessão de ~2h (4-6 issues XS/S/M).
+Contexto: App React 19 + Framer Motion — escritório virtual 2D com avatares de agentes IA.
 
 Issues abertas:
 $OPEN_ISSUES
 
-Sizes: XS<10min | S~15min | M~30min(máx) | L/XL=quebrar antes
+Critérios: priority:high primeiro, dependências técnicas antes de feat, equilibrar feat/test/chore, sprint realista 1 dev 80h.
 
-Selecione 4-6 issues priorizando: priority:high > medium > low.
-Se uma issue for grande demais, indique para quebrar.
-
-Responda SOMENTE em JSON válido:
+Responda EXATAMENTE neste JSON (sem texto fora do JSON):
 {
-  \"goal\": \"objetivo do sprint em 1 frase\",
-  \"capacity\": \"~2h, N issues\",
-  \"selected\": [{\"issue\": 0, \"reason\": \"motivo curto\"}],
-  \"defer\": [{\"issue\": 0, \"reason\": \"motivo ou quebrar\"}]
+  \"sprint_goal\": \"<objetivo em 1 frase>\",
+  \"capacity\": \"<estimativa total>\",
+  \"selected\": [{\"issue\": 0, \"priority\": \"alta|media|baixa\", \"reason\": \"<justificativa>\", \"size\": \"XS|S|M|L|XL\"}],
+  \"deferred\": [{\"issue\": 0, \"reason\": \"<motivo>\"}],
+  \"risks\": [\"<risco>\"]
 }"
 
-TMPFILE=$(mktemp)
-printf '%s' "$PROMPT" > "$TMPFILE"
+# ── Tentar Celebro primeiro ────────────────────────────────────────────────────
+PLAN=""
+BACKEND=""
 
-RAW=$(timeout 60 "$OPENCODE" run -m "$MODEL" "$(cat "$TMPFILE")" 2>&1 \
-  | sed 's/\x1b\[[0-9;]*[A-Za-z]//g')
-rm -f "$TMPFILE"
+RESPONSE=$(python3 - "$CELEBRO_URL" <<PYEOF
+import sys, json, urllib.request
 
-PLAN=$(echo "$RAW" | python3 -c "
+celebro_url = sys.argv[1]
+
+prompt = """$PROMPT"""
+
+payload = json.dumps({"text": prompt, "agent": "rx-orchestrator"}).encode()
+req = urllib.request.Request(celebro_url, data=payload,
+      headers={"Content-Type": "application/json"})
+try:
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        data = json.loads(resp.read())
+        print(data.get("response", ""))
+except Exception:
+    pass
+PYEOF
+)
+
+PLAN=$(echo "$RESPONSE" | python3 -c "
 import sys, json, re
 text = sys.stdin.read()
 match = re.search(r'\{[\s\S]*\}', text)
 if match:
     try:
         print(json.dumps(json.loads(match.group(0)), indent=2, ensure_ascii=False))
+    except:
+        pass
+" 2>/dev/null || echo "")
+[[ -n "$PLAN" ]] && BACKEND="celebro"
+
+# ── Fallback para OpenCode se Celebro falhou ──────────────────────────────────
+if [[ -z "$PLAN" ]]; then
+  if [ ! -f "$OPENCODE" ]; then
+    echo "⚠️  Celebro indisponível e OpenCode não encontrado em $OPENCODE"
+    exit 1
+  fi
+  echo "   Celebro indisponível — usando OpenCode..."
+  TMPFILE=$(mktemp)
+  printf '%s' "$PROMPT" > "$TMPFILE"
+  RAW=$(timeout 60 "$OPENCODE" run -m "$MODEL" "$(cat "$TMPFILE")" 2>&1 \
+    | sed 's/\x1b\[[0-9;]*[A-Za-z]//g')
+  rm -f "$TMPFILE"
+
+  # Normalizar JSON do OpenCode para formato Celebro
+  PLAN=$(echo "$RAW" | python3 -c "
+import sys, json, re
+text = sys.stdin.read()
+match = re.search(r'\{[\s\S]*\}', text)
+if match:
+    try:
+        d = json.loads(match.group(0))
+        # Normalizar: goal -> sprint_goal
+        if 'goal' in d and 'sprint_goal' not in d:
+            d['sprint_goal'] = d.pop('goal')
+        # Normalizar: defer -> deferred
+        if 'defer' in d and 'deferred' not in d:
+            d['deferred'] = d.pop('defer')
+        # Normalizar selected: adicionar campos faltantes
+        for s in d.get('selected', []):
+            if 'priority' not in s: s['priority'] = 'media'
+            if 'size' not in s: s['size'] = 'M'
+        print(json.dumps(d, indent=2, ensure_ascii=False))
     except Exception:
         print(text)
-else:
-    print(text)
-")
+" 2>/dev/null || echo "")
+  [[ -n "$PLAN" ]] && BACKEND="opencode"
+fi
+
+if [[ -z "$PLAN" ]]; then
+  echo "⚠️  Nenhum backend disponível — planejamento indisponível"
+  exit 1
+fi
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🎯 Plano rx-orchestrator [via $BACKEND]"
+echo ""
 echo "$PLAN" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
-    print(f\"Goal: {d.get('goal','?')}\")
+    print(f\"Sprint Goal: {d.get('sprint_goal','?')}\")
     print(f\"Capacidade: {d.get('capacity','?')}\")
     print()
     print('✅ Selecionadas:')
     for s in d.get('selected', []):
-        print(f\"  #{s['issue']} — {s['reason']}\")
-    defer = d.get('defer', [])
-    if defer:
+        print(f\"  #{s['issue']} [{s.get('size','?')}] {s.get('priority','?').upper()} — {s.get('reason','')}\")
+    deferred = d.get('deferred', [])
+    if deferred:
         print()
-        print('⏭  Adiadas:')
-        for s in defer:
-            print(f\"  #{s['issue']} — {s['reason']}\")
-except Exception:
+        print('⏭️  Adiadas:')
+        for s in deferred:
+            print(f\"  #{s['issue']} — {s.get('reason','')}\")
+    risks = d.get('risks', [])
+    if risks:
+        print()
+        print('⚠️  Riscos:')
+        for r in risks:
+            print(f'  - {r}')
+except:
     print(sys.stdin.read())
 " 2>/dev/null || echo "$PLAN"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+# ── Postar como issue de sprint no repo ───────────────────────────────────────
 if [ -n "$POST_COMMENT" ]; then
-  BODY=$(echo "$PLAN" | python3 -c "
+  SPRINT_BODY=$(echo "$PLAN" | python3 -c "
 import sys, json
 from datetime import date, timedelta
 try:
     d = json.load(sys.stdin)
     today = date.today()
-    end   = today + timedelta(days=14)
+    end = today + timedelta(days=14)
+    goal     = d.get('sprint_goal','?')
+    capacity = d.get('capacity','?')
+    selected = d.get('selected', [])
+    deferred = d.get('deferred', [])
+    risks    = d.get('risks', [])
+
     lines = [
         f'## Sprint {today} → {end}',
-        f'**Goal:** {d.get(\"goal\",\"?\")}',
-        f'**Capacidade:** {d.get(\"capacity\",\"?\")}',
         '',
-        '## Issues',
-        '| # | Motivo |',
-        '|---|--------|',
+        f'**Goal:** {goal}',
+        f'**Capacidade:** {capacity}',
+        '',
+        '## Issues do Sprint',
+        '',
+        '| Issue | Size | Prioridade | Justificativa |',
+        '|-------|------|------------|---------------|',
     ]
-    for s in d.get('selected', []):
-        lines.append(f'| #{s[\"issue\"]} | {s[\"reason\"]} |')
-    defer = d.get('defer', [])
-    if defer:
+    for s in selected:
+        lines.append(f\"| #{s['issue']} | {s.get('size','?')} | {s.get('priority','?')} | {s.get('reason','')} |\")
+    if deferred:
         lines.append('')
         lines.append('## Adiadas')
-        for s in defer:
-            lines.append(f'- #{s[\"issue\"]}: {s[\"reason\"]}')
+        for s in deferred:
+            lines.append(f\"- #{s['issue']}: {s.get('reason','')}\")
+    if risks:
+        lines.append('')
+        lines.append('## Riscos do Sprint')
+        for r in risks:
+            lines.append(f'- ⚠️ {r}')
+    lines.append('')
+    lines.append('---')
+    lines.append('*Planejamento automático via rx-orchestrator (MAGO)*')
     print('\n'.join(lines))
-except Exception:
+except Exception as e:
+    print(f'Erro ao formatar: {e}')
     print(sys.stdin.read())
 ")
+
+  SPRINT_TITLE="chore(sprint): planejamento $(date +%Y-%m-%d)"
   gh issue create \
-    --title "chore(sprint): planejamento $(date +%Y-%m-%d)" \
-    --body "$BODY" \
+    --title "$SPRINT_TITLE" \
+    --body "$SPRINT_BODY" \
     --label "chore" \
     && echo "✅ Issue de sprint criada!"
 fi

--- a/scripts/pr-review.sh
+++ b/scripts/pr-review.sh
@@ -165,7 +165,9 @@ $REVIEW
   EXISTING_IDS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
     --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("## 🤖 AI Code Review")) | .id')
   for CID in $EXISTING_IDS; do
-    gh api -X DELETE "repos/$REPO/issues/comments/$CID" && echo "🗑️  Comentário anterior removido ($CID)"
+    gh api -X DELETE "repos/$REPO/issues/comments/$CID" \
+      && echo "🗑️  Comentário anterior removido ($CID)" \
+      || echo "⚠️  Não foi possível remover comentário anterior ($CID)"
   done
 
   gh pr comment "$PR_NUMBER" --body "$FORMAT_REVIEW"


### PR DESCRIPTION
## O que estava errado

Na PR #55, ao integrar OpenCode nos scripts, o conteúdo original (Celebro) foi **substituído** em vez de **mesclado**.

## Fixes

- **mago-estimate.sh**: Celebro como primário, OpenCode como fallback automático quando offline
- **mago-sprint.sh**: idem — Celebro primário, OpenCode fallback
- **branch-create.sh**: removido check de Celebro duplicado — delega ao mago-estimate.sh
- **pr-review.sh**: corrigido crash com `set -e` no loop de delete de comentários anteriores (sem `|| true` o script morria ao tentar deletar comentários sem permissão `issues:write`)
- **project-automation.yml**: restaurado fallback graceful do token (`GH_PAT || GITHUB_TOKEN` em vez de `exit 1`)