### PR TITLE
chore(i18n): migrate codebase to english

### DIFF
--- a/src/components/AgentAvatar.test.tsx
+++ b/src/components/AgentAvatar.test.tsx
@@ -33,7 +33,7 @@ const mockAgent: AgentOfficeData = {
   name: 'Architect',
   role: 'architect',
   status: 'idle',
-  currentTask: 'Aguardando próximo ciclo',
+  currentTask: 'Waiting for next cycle',
   zoneId: 'coffee-corner',
   position: { x: 30, y: 50 },
   color: '#8b5cf6',
@@ -41,27 +41,27 @@ const mockAgent: AgentOfficeData = {
 }
 
 describe('AgentAvatar', () => {
-  it('renderiza o nome do agente', () => {
+  it('renders the agent name', () => {
     render(<AgentAvatar agent={mockAgent} />)
     expect(screen.getByText('Architect')).toBeTruthy()
   })
 
-  it('renderiza o ícone correto para role architect', () => {
+  it('renders the correct icon for role architect', () => {
     render(<AgentAvatar agent={mockAgent} />)
     expect(screen.getByText('🤖')).toBeTruthy()
   })
 
-  it('renderiza ícone correto para role backend', () => {
+  it('renders the correct icon for role backend', () => {
     render(<AgentAvatar agent={{ ...mockAgent, role: 'backend' }} />)
     expect(screen.getByText('🔬')).toBeTruthy()
   })
 
-  it('renderiza ícone correto para role orchestrator', () => {
+  it('renders the correct icon for role orchestrator', () => {
     render(<AgentAvatar agent={{ ...mockAgent, role: 'orchestrator' }} />)
     expect(screen.getByText('⚡')).toBeTruthy()
   })
 
-  it('chama onClick ao clicar', () => {
+  it('calls onClick when clicked', () => {
     const onClick = vi.fn()
     render(<AgentAvatar agent={mockAgent} onClick={onClick} />)
     const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
@@ -69,33 +69,33 @@ describe('AgentAvatar', () => {
     expect(onClick).toHaveBeenCalledWith(mockAgent)
   })
 
-  it('não renderiza SpeechBubble quando speechText é null', () => {
+  it('does not render SpeechBubble when speechText is null', () => {
     render(<AgentAvatar agent={mockAgent} />)
-    expect(screen.queryByText(/aguardando/i)).toBeNull()
+    expect(screen.queryByText(/waiting/i)).toBeNull()
   })
 
-  it('renderiza SpeechBubble quando speechText está preenchido', () => {
-    render(<AgentAvatar agent={{ ...mockAgent, speechText: 'Analisando código' }} />)
-    expect(screen.getByText('Analisando código')).toBeTruthy()
+  it('renders SpeechBubble when speechText is set', () => {
+    render(<AgentAvatar agent={{ ...mockAgent, speechText: 'Analyzing code' }} />)
+    expect(screen.getByText('Analyzing code')).toBeTruthy()
   })
 
-  it('badge tem aria-label com o status atual', () => {
+  it('badge has aria-label with current status', () => {
     render(<AgentAvatar agent={mockAgent} />)
     expect(document.querySelector('[aria-label="status: idle"]')).toBeTruthy()
   })
 
-  it('agente offline tem opacidade reduzida', () => {
+  it('offline agent has reduced opacity', () => {
     render(<AgentAvatar agent={{ ...mockAgent, status: 'offline' }} />)
     const circle = document.querySelector('[style*="opacity: 0.35"]')
     expect(circle).toBeTruthy()
   })
 
-  it('tem aria-label com nome e status do agente', () => {
+  it('has aria-label with agent name and status', () => {
     render(<AgentAvatar agent={mockAgent} />)
     expect(document.querySelector('[aria-label*="Architect"]')).toBeTruthy()
   })
 
-  describe('tooltip com fake timers', () => {
+  describe('tooltip with fake timers', () => {
     beforeEach(() => {
       vi.useFakeTimers()
     })
@@ -103,7 +103,7 @@ describe('AgentAvatar', () => {
       vi.useRealTimers()
     })
 
-    it('tooltip aparece após 400ms de hover', () => {
+    it('tooltip appears after 400ms of hover', () => {
       render(<AgentAvatar agent={mockAgent} />)
       const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
       fireEvent.mouseEnter(container)
@@ -114,7 +114,7 @@ describe('AgentAvatar', () => {
       expect(screen.getByRole('tooltip')).toBeTruthy()
     })
 
-    it('tooltip desaparece ao mouseLeave', () => {
+    it('tooltip disappears on mouseLeave', () => {
       render(<AgentAvatar agent={mockAgent} />)
       const container = document.querySelector('[style*="position: absolute"]') as HTMLElement
       fireEvent.mouseEnter(container)

--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -12,16 +12,16 @@ interface AgentAvatarProps {
   isSelected?: boolean
 }
 
-/** Ícone por role do agente */
+/** Icon per agent role */
 const ROLE_ICON: Record<string, string> = {
-  architect:    '🤖',
-  backend:      '🔬',
+  architect: '🤖',
+  backend: '🔬',
   orchestrator: '⚡',
 }
 
 const DEFAULT_ICON = '🤖'
 
-/** Animações Framer Motion por status */
+/** Framer Motion animations per status */
 const STATUS_ANIMATION: Record<string, TargetAndTransition> = {
   idle: {
     y: [0, -4, 0],
@@ -42,18 +42,22 @@ const STATUS_ANIMATION: Record<string, TargetAndTransition> = {
   offline: {},
 }
 
-/** Cor do badge de status */
+/** Status badge color */
 const STATUS_BADGE_COLOR: Record<string, string> = {
-  idle:      '#6b7280',
-  working:   '#00ff41',
-  thinking:  '#f59e0b',
-  blocked:   '#ef4444',
-  offline:   '#374151',
+  idle: '#6b7280',
+  working: '#00ff41',
+  thinking: '#f59e0b',
+  blocked: '#ef4444',
+  offline: '#374151',
 }
 
 const TOOLTIP_DELAY_MS = 400
 
-export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelected = false }: AgentAvatarProps) {
+export const AgentAvatar = memo(function AgentAvatar({
+  agent,
+  onClick,
+  isSelected = false,
+}: AgentAvatarProps) {
   const icon = ROLE_ICON[agent.role] ?? DEFAULT_ICON
   const animation = STATUS_ANIMATION[agent.status] ?? {}
   const badgeColor = STATUS_BADGE_COLOR[agent.status] ?? '#6b7280'
@@ -70,24 +74,38 @@ export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelecte
     setShowTooltip(false)
   }, [])
 
-  // Cleanup do timer no unmount para evitar memory leak
+  // Cleanup timer on unmount to avoid memory leak
   useEffect(() => {
     return () => {
       if (tooltipTimer.current) clearTimeout(tooltipTimer.current)
     }
   }, [])
 
-  const tooltipLines = useMemo(() => [
-    { label: 'role', value: agent.role },
-    { label: 'status', value: AGENT_STATUS_LABEL[agent.status] ?? agent.status, valueColor: badgeColor },
-    ...(agent.currentTask ? [{ label: 'task', value: agent.currentTask.slice(0, 28) + (agent.currentTask.length > 28 ? '…' : '') }] : []),
-    ...(agent.zoneId ? [{ label: 'zona', value: agent.zoneId }] : []),
-  ], [agent.role, agent.status, agent.currentTask, agent.zoneId, badgeColor])
+  const tooltipLines = useMemo(
+    () => [
+      { label: 'role', value: agent.role },
+      {
+        label: 'status',
+        value: AGENT_STATUS_LABEL[agent.status] ?? agent.status,
+        valueColor: badgeColor,
+      },
+      ...(agent.currentTask
+        ? [
+            {
+              label: 'task',
+              value: agent.currentTask.slice(0, 28) + (agent.currentTask.length > 28 ? '…' : ''),
+            },
+          ]
+        : []),
+      ...(agent.zoneId ? [{ label: 'zone', value: agent.zoneId }] : []),
+    ],
+    [agent.role, agent.status, agent.currentTask, agent.zoneId, badgeColor]
+  )
 
   return (
     <motion.div
       layoutId={`agent-${agent.id}`}
-      aria-label={`agente ${agent.name}, status ${AGENT_STATUS_LABEL[agent.status] ?? agent.status}`}
+      aria-label={`agent ${agent.name}, status ${AGENT_STATUS_LABEL[agent.status] ?? agent.status}`}
       style={{
         position: 'absolute',
         left: `${agent.position.x}%`,
@@ -110,10 +128,10 @@ export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelecte
         {showTooltip && <AvatarTooltip lines={tooltipLines} placement="top" />}
       </AnimatePresence>
 
-      {/* Balão de fala */}
+      {/* Speech bubble */}
       <SpeechBubble text={agent.speechText} color={agent.color} />
 
-      {/* Avatar circular */}
+      {/* Circular avatar */}
       <motion.div
         animate={animation}
         style={{
@@ -128,13 +146,17 @@ export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelecte
           justifyContent: 'center',
           fontSize: 16,
           opacity: isOffline ? 0.35 : 1,
-          boxShadow: isOffline ? 'none' : isSelected ? `0 0 0 2px ${agent.color}, 0 0 14px ${agent.color}88` : `0 0 8px ${agent.color}44`,
+          boxShadow: isOffline
+            ? 'none'
+            : isSelected
+              ? `0 0 0 2px ${agent.color}, 0 0 14px ${agent.color}88`
+              : `0 0 8px ${agent.color}44`,
           transition: 'box-shadow 0.2s ease',
         }}
       >
         {icon}
 
-        {/* Badge de status */}
+        {/* Status badge */}
         <span
           aria-label={`status: ${agent.status}`}
           style={{
@@ -151,7 +173,7 @@ export const AgentAvatar = memo(function AgentAvatar({ agent, onClick, isSelecte
         />
       </motion.div>
 
-      {/* Nome do agente */}
+      {/* Agent name */}
       <span
         style={{
           fontFamily: 'JetBrains Mono, monospace',

--- a/src/components/AgentDetailPanel.test.tsx
+++ b/src/components/AgentDetailPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { AgentDetailPanel } from './AgentDetailPanel'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
 
-// jsdom não implementa scrollIntoView
+// scrollIntoView is not implemented in happy-dom
 window.HTMLElement.prototype.scrollIntoView = vi.fn()
 
 vi.mock('framer-motion', async () => {
@@ -11,11 +11,33 @@ vi.mock('framer-motion', async () => {
   return {
     ...actual,
     motion: {
-      div: ({ children, style, variants: _v, initial: _i, animate: _a, exit: _e, transition: _t, layout: _l, ...rest }: React.HTMLAttributes<HTMLDivElement> & Record<string, unknown>) => (
-        <div style={style} {...rest}>{children}</div>
+      div: ({
+        children,
+        style,
+        variants: _v,
+        initial: _i,
+        animate: _a,
+        exit: _e,
+        transition: _t,
+        layout: _l,
+        ...rest
+      }: React.HTMLAttributes<HTMLDivElement> & Record<string, unknown>) => (
+        <div style={style} {...rest}>
+          {children}
+        </div>
       ),
-      aside: ({ children, style, variants: _v, initial: _i, animate: _a, exit: _e, ...rest }: React.HTMLAttributes<HTMLElement> & Record<string, unknown>) => (
-        <aside style={style} {...rest}>{children}</aside>
+      aside: ({
+        children,
+        style,
+        variants: _v,
+        initial: _i,
+        animate: _a,
+        exit: _e,
+        ...rest
+      }: React.HTMLAttributes<HTMLElement> & Record<string, unknown>) => (
+        <aside style={style} {...rest}>
+          {children}
+        </aside>
       ),
     },
     AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -27,7 +49,7 @@ const mockAgent: AgentOfficeData = {
   name: 'Architect',
   role: 'architect',
   status: 'working',
-  currentTask: 'Revisando PR #44',
+  currentTask: 'Reviewing PR #44',
   zoneId: 'dev-zone',
   position: { x: 50, y: 50 },
   color: '#8b5cf6',
@@ -45,127 +67,127 @@ describe('AgentDetailPanel', () => {
     vi.unstubAllGlobals()
   })
 
-  it('exibe o nome do agente no header', () => {
+  it('shows agent name in header', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
     expect(screen.getByText('Architect')).toBeTruthy()
   })
 
-  it('exibe o role do agente', () => {
+  it('shows agent role', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
     expect(screen.getByText('architect')).toBeTruthy()
   })
 
-  it('exibe status e zona', () => {
+  it('shows status and zone', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    expect(screen.getByText('ZONA')).toBeTruthy()
+    expect(screen.getByText('ZONE')).toBeTruthy()
     expect(screen.getByText('dev-zone')).toBeTruthy()
   })
 
-  it('exibe a task atual', () => {
+  it('shows current task', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    expect(screen.getByText('Revisando PR #44')).toBeTruthy()
+    expect(screen.getByText('Reviewing PR #44')).toBeTruthy()
   })
 
-  it('não exibe seção task quando currentTask está vazio', () => {
-    const agentSemTask = { ...mockAgent, currentTask: '' }
-    render(<AgentDetailPanel agent={agentSemTask} onClose={onClose} />)
-    expect(screen.queryByText('TASK ATUAL')).toBeNull()
+  it('does not show task section when currentTask is empty', () => {
+    const agentNoTask = { ...mockAgent, currentTask: '' }
+    render(<AgentDetailPanel agent={agentNoTask} onClose={onClose} />)
+    expect(screen.queryByText('CURRENT TASK')).toBeNull()
   })
 
-  it('chama onClose ao clicar no botão fechar', () => {
+  it('calls onClose when close button is clicked', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    fireEvent.click(screen.getByLabelText('Fechar painel'))
+    fireEvent.click(screen.getByLabelText('Close panel'))
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('chama onClose ao pressionar Escape', () => {
+  it('calls onClose when Escape is pressed', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('chama onClose ao clicar no overlay', () => {
+  it('calls onClose when overlay is clicked', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
     const overlay = document.querySelector('[aria-hidden="true"]') as HTMLElement
     fireEvent.click(overlay)
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('tem role complementary e aria-label', () => {
+  it('has complementary role and aria-label', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    expect(screen.getByRole('complementary', { name: /detalhes do agente Architect/i })).toBeTruthy()
+    expect(screen.getByRole('complementary', { name: /Agent details: Architect/i })).toBeTruthy()
   })
 
-  it('exibe mensagens rápidas predefinidas', () => {
+  it('shows predefined quick messages', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    expect(screen.getByText('Qual sua task atual?')).toBeTruthy()
-    expect(screen.getByText('Pause e aguarde')).toBeTruthy()
+    expect(screen.getByText('What is your current task?')).toBeTruthy()
+    expect(screen.getByText('Pause and wait')).toBeTruthy()
   })
 
-  it('input de mensagem está presente', () => {
+  it('message input is present', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    expect(screen.getByLabelText('mensagem para o agente')).toBeTruthy()
+    expect(screen.getByLabelText('message to agent')).toBeTruthy()
   })
 
-  it('botão send está desabilitado com input vazio', () => {
+  it('send button is disabled with empty input', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    const btn = screen.getByLabelText('enviar mensagem') as HTMLButtonElement
+    const btn = screen.getByLabelText('send message') as HTMLButtonElement
     expect(btn.disabled).toBe(true)
   })
 
-  it('botão send habilita ao digitar mensagem', () => {
+  it('send button enables when message is typed', () => {
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    const input = screen.getByLabelText('mensagem para o agente')
-    fireEvent.change(input, { target: { value: 'olá agente' } })
-    const btn = screen.getByLabelText('enviar mensagem') as HTMLButtonElement
+    const input = screen.getByLabelText('message to agent')
+    fireEvent.change(input, { target: { value: 'hello agent' } })
+    const btn = screen.getByLabelText('send message') as HTMLButtonElement
     expect(btn.disabled).toBe(false)
   })
 
-  it('envia mensagem com fetch e exibe no histórico', async () => {
+  it('sends message with fetch and shows it in history', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ response: 'Tudo certo!' }),
+      json: async () => ({ response: 'All good!' }),
     })
     vi.stubGlobal('fetch', fetchMock)
 
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    const input = screen.getByLabelText('mensagem para o agente')
-    fireEvent.change(input, { target: { value: 'Qual a task?' } })
-    fireEvent.click(screen.getByLabelText('enviar mensagem'))
+    const input = screen.getByLabelText('message to agent')
+    fireEvent.change(input, { target: { value: 'What is the task?' } })
+    fireEvent.click(screen.getByLabelText('send message'))
 
-    // Mensagem do usuário aparece imediatamente
-    expect(screen.getByText('Qual a task?')).toBeTruthy()
+    // User message appears immediately
+    expect(screen.getByText('What is the task?')).toBeTruthy()
 
-    // Resposta do agente aparece após fetch
-    await waitFor(() => expect(screen.getByText('Tudo certo!')).toBeTruthy())
-    await waitFor(() => expect(screen.getByText('Mensagem enviada!')).toBeTruthy())
+    // Agent response appears after fetch
+    await waitFor(() => expect(screen.getByText('All good!')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('Message sent!')).toBeTruthy())
   })
 
-  it('exibe erro quando fetch falha', async () => {
+  it('shows error when fetch fails', async () => {
     const fetchMock = vi.fn().mockRejectedValueOnce(new Error('Network error'))
     vi.stubGlobal('fetch', fetchMock)
 
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    const input = screen.getByLabelText('mensagem para o agente')
-    fireEvent.change(input, { target: { value: 'teste' } })
-    fireEvent.click(screen.getByLabelText('enviar mensagem'))
+    const input = screen.getByLabelText('message to agent')
+    fireEvent.change(input, { target: { value: 'test' } })
+    fireEvent.click(screen.getByLabelText('send message'))
 
-    await waitFor(() => expect(screen.getByText('Erro ao enviar. Tente novamente.')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('Failed to send. Please try again.')).toBeTruthy())
   })
 
-  it('exibe erro quando fetch retorna status não-ok', async () => {
+  it('shows error when fetch returns non-ok status', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 })
     vi.stubGlobal('fetch', fetchMock)
 
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    const input = screen.getByLabelText('mensagem para o agente')
-    fireEvent.change(input, { target: { value: 'teste' } })
-    fireEvent.click(screen.getByLabelText('enviar mensagem'))
+    const input = screen.getByLabelText('message to agent')
+    fireEvent.change(input, { target: { value: 'test' } })
+    fireEvent.click(screen.getByLabelText('send message'))
 
-    await waitFor(() => expect(screen.getByText('Erro ao enviar. Tente novamente.')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('Failed to send. Please try again.')).toBeTruthy())
   })
 
-  it('click em quick message envia mensagem', async () => {
+  it('clicking a quick message sends it', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({ response: 'ok' }),
@@ -173,7 +195,7 @@ describe('AgentDetailPanel', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     render(<AgentDetailPanel agent={mockAgent} onClose={onClose} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Qual sua task atual?' }))
+    fireEvent.click(screen.getByRole('button', { name: 'What is your current task?' }))
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
   })

--- a/src/components/AgentDetailPanel.tsx
+++ b/src/components/AgentDetailPanel.tsx
@@ -17,15 +17,15 @@ interface ChatMessage {
 
 const PANEL_VARIANTS = {
   hidden: { x: '100%', opacity: 0 },
-  visible: { x: 0, opacity: 1, transition: { type: 'spring' as const, damping: 20, stiffness: 200 } },
+  visible: {
+    x: 0,
+    opacity: 1,
+    transition: { type: 'spring' as const, damping: 20, stiffness: 200 },
+  },
   exit: { x: '100%', opacity: 0, transition: { duration: 0.2 } },
 }
 
-const QUICK_MESSAGES = [
-  'Qual sua task atual?',
-  'Pause e aguarde',
-  'Continue normalmente',
-]
+const QUICK_MESSAGES = ['What is your current task?', 'Pause and wait', 'Continue normally']
 
 const CELEBRO_URL =
   (import.meta.env.VITE_CELEBRO_URL as string | undefined) ?? 'http://localhost:3099/chat'
@@ -33,7 +33,7 @@ const CELEBRO_URL =
 const FETCH_TIMEOUT_MS = 10_000
 
 function formatTime(date: Date): string {
-  return date.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+  return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
 }
 
 export const AgentDetailPanel = memo(function AgentDetailPanel({
@@ -51,7 +51,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
   const statusColor = STATUS_COLOR[agent.status as keyof typeof STATUS_COLOR] ?? '#6b7280'
   const statusLabel = STATUS_LABEL[agent.status as keyof typeof STATUS_LABEL] ?? agent.status
 
-  // Fechar com Escape
+  // Close with Escape
   useEffect(() => {
     function onKey(e: globalThis.KeyboardEvent) {
       if (e.key === 'Escape') onClose()
@@ -60,12 +60,12 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
-  // Focar input ao abrir
+  // Focus input on open
   useEffect(() => {
     inputRef.current?.focus()
   }, [])
 
-  // Scroll para última mensagem
+  // Scroll to last message
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
@@ -80,7 +80,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
         text: text.trim(),
         timestamp: new Date(),
       }
-      setMessages(prev => [...prev, userMsg])
+      setMessages((prev) => [...prev, userMsg])
       setInput('')
       setIsSending(true)
       setSendFeedback(null)
@@ -92,7 +92,11 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
         const res = await fetch(CELEBRO_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message: text.trim(), context: 'office-view', agentHint: agent.id }),
+          body: JSON.stringify({
+            message: text.trim(),
+            context: 'office-view',
+            agentHint: agent.id,
+          }),
           signal: controller.signal,
         })
         clearTimeout(timeoutId)
@@ -106,16 +110,16 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
           text: data.response ?? 'OK',
           timestamp: new Date(),
         }
-        setMessages(prev => [...prev, agentMsg])
-        setSendFeedback('Mensagem enviada!')
+        setMessages((prev) => [...prev, agentMsg])
+        setSendFeedback('Message sent!')
       } catch {
-        setSendFeedback('Erro ao enviar. Tente novamente.')
+        setSendFeedback('Failed to send. Please try again.')
       } finally {
         setIsSending(false)
         setTimeout(() => setSendFeedback(null), 3000)
       }
     },
-    [agent.id, isSending],
+    [agent.id, isSending]
   )
 
   function handleSubmit(e: React.FormEvent) {
@@ -125,7 +129,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
 
   return (
     <>
-      {/* Overlay para fechar clicando fora */}
+      {/* Overlay to close when clicking outside */}
       <div
         aria-hidden="true"
         onClick={onClose}
@@ -136,10 +140,10 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
         }}
       />
 
-      {/* Painel */}
+      {/* Panel */}
       <motion.aside
         role="complementary"
-        aria-label={`Detalhes do agente ${agent.name}`}
+        aria-label={`Agent details: ${agent.name}`}
         variants={PANEL_VARIANTS}
         initial="hidden"
         animate="visible"
@@ -186,7 +190,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
             </div>
           </div>
           <button
-            aria-label="Fechar painel"
+            aria-label="Close panel"
             onClick={onClose}
             style={{
               background: 'none',
@@ -202,7 +206,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
           </button>
         </div>
 
-        {/* Status + Zona */}
+        {/* Status + Zone */}
         <div
           style={{
             padding: '10px 16px',
@@ -217,12 +221,12 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
             <div style={{ color: statusColor, fontWeight: 700 }}>{statusLabel}</div>
           </div>
           <div>
-            <div style={{ color: '#4b5563', marginBottom: 2 }}>ZONA</div>
+            <div style={{ color: '#4b5563', marginBottom: 2 }}>ZONE</div>
             <div style={{ color: '#9ca3af' }}>{agent.zoneId}</div>
           </div>
         </div>
 
-        {/* Task atual */}
+        {/* Current task */}
         {agent.currentTask && (
           <div
             style={{
@@ -232,7 +236,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
             }}
           >
             <div style={{ color: '#4b5563', marginBottom: 4, letterSpacing: '0.08em' }}>
-              TASK ATUAL
+              CURRENT TASK
             </div>
             <div
               style={{
@@ -246,9 +250,9 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
           </div>
         )}
 
-        {/* Mensagens da sessão */}
+        {/* Session messages */}
         <div
-          aria-label="histórico de mensagens"
+          aria-label="message history"
           style={{
             flex: 1,
             overflowY: 'auto',
@@ -260,11 +264,11 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
         >
           {messages.length === 0 && (
             <div style={{ color: '#374151', fontSize: 10, textAlign: 'center', marginTop: 20 }}>
-              nenhuma mensagem ainda
+              no messages yet
             </div>
           )}
           <AnimatePresence initial={false}>
-            {messages.map(msg => (
+            {messages.map((msg) => (
               <motion.div
                 key={msg.id}
                 initial={{ opacity: 0, y: 6 }}
@@ -309,7 +313,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
             flexWrap: 'wrap',
           }}
         >
-          {QUICK_MESSAGES.map(q => (
+          {QUICK_MESSAGES.map((q) => (
             <button
               key={q}
               onClick={() => void sendMessage(q)}
@@ -331,7 +335,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
           ))}
         </div>
 
-        {/* Input */}
+        {/* Input form */}
         <form
           onSubmit={handleSubmit}
           style={{
@@ -345,10 +349,10 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
           <input
             ref={inputRef}
             value={input}
-            onChange={e => setInput(e.target.value)}
-            placeholder="mensagem para o agente..."
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="message to agent..."
             disabled={isSending}
-            aria-label="mensagem para o agente"
+            aria-label="message to agent"
             style={{
               flex: 1,
               background: '#161b22',
@@ -364,7 +368,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
           <button
             type="submit"
             disabled={isSending || !input.trim()}
-            aria-label="enviar mensagem"
+            aria-label="send message"
             style={{
               background: input.trim() && !isSending ? `${color}22` : '#1f2937',
               border: `1px solid ${input.trim() && !isSending ? `${color}44` : '#374151'}`,
@@ -381,7 +385,7 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
           </button>
         </form>
 
-        {/* Feedback de envio */}
+        {/* Send feedback */}
         <AnimatePresence>
           {sendFeedback && (
             <motion.div
@@ -394,11 +398,11 @@ export const AgentDetailPanel = memo(function AgentDetailPanel({
                 left: 16,
                 right: 16,
                 padding: '4px 10px',
-                background: sendFeedback.startsWith('Erro') ? '#7f1d1d' : '#14532d',
-                border: `1px solid ${sendFeedback.startsWith('Erro') ? '#991b1b' : '#166534'}`,
+                background: sendFeedback.startsWith('Failed') ? '#7f1d1d' : '#14532d',
+                border: `1px solid ${sendFeedback.startsWith('Failed') ? '#991b1b' : '#166534'}`,
                 borderRadius: 4,
                 fontSize: 10,
-                color: sendFeedback.startsWith('Erro') ? '#fca5a5' : '#86efac',
+                color: sendFeedback.startsWith('Failed') ? '#fca5a5' : '#86efac',
                 textAlign: 'center',
               }}
             >

--- a/src/components/AvatarTooltip.test.tsx
+++ b/src/components/AvatarTooltip.test.tsx
@@ -5,30 +5,30 @@ import { AvatarTooltip } from './AvatarTooltip'
 const lines = [
   { label: 'role', value: 'architect' },
   { label: 'status', value: 'working', valueColor: '#00ff41' },
-  { label: 'task', value: 'Revisando PR #44' },
+  { label: 'task', value: 'Reviewing PR #44' },
 ]
 
 describe('AvatarTooltip', () => {
-  it('tem role tooltip', () => {
+  it('has tooltip role', () => {
     render(<AvatarTooltip lines={lines} />)
     expect(screen.getByRole('tooltip')).toBeTruthy()
   })
 
-  it('exibe todas as linhas de conteúdo', () => {
+  it('displays all content lines', () => {
     render(<AvatarTooltip lines={lines} />)
     expect(screen.getByText('architect')).toBeTruthy()
     expect(screen.getByText('working')).toBeTruthy()
-    expect(screen.getByText('Revisando PR #44')).toBeTruthy()
+    expect(screen.getByText('Reviewing PR #44')).toBeTruthy()
   })
 
-  it('exibe os labels de cada linha', () => {
+  it('displays the label of each line', () => {
     render(<AvatarTooltip lines={lines} />)
     expect(screen.getByText('role')).toBeTruthy()
     expect(screen.getByText('status')).toBeTruthy()
     expect(screen.getByText('task')).toBeTruthy()
   })
 
-  it('renderiza com placement bottom', () => {
+  it('renders with bottom placement', () => {
     const { container } = render(<AvatarTooltip lines={lines} placement="bottom" />)
     expect(container.firstChild).toBeTruthy()
   })

--- a/src/components/AvatarTooltip.tsx
+++ b/src/components/AvatarTooltip.tsx
@@ -10,7 +10,7 @@ export interface TooltipLine {
 
 interface AvatarTooltipProps {
   lines: TooltipLine[]
-  /** Posiciona acima (padrão) ou abaixo */
+  /** Positions above (default) or below */
   placement?: 'top' | 'bottom'
 }
 

--- a/src/components/HumanAvatar.test.tsx
+++ b/src/components/HumanAvatar.test.tsx
@@ -13,7 +13,30 @@ vi.mock('framer-motion', async () => {
   return {
     ...actual,
     motion: {
-      div: ({ children, style, drag, role, 'aria-label': ariaLabel, 'aria-grabbed': ariaGrabbed, tabIndex, onDragEnd: _ode, dragConstraints: _dc, dragElastic: _de, whileDrag: _wd, animate: _an, transition: _tr, ...rest }: React.HTMLAttributes<HTMLDivElement> & { drag?: boolean; onDragEnd?: unknown; dragConstraints?: unknown; dragElastic?: unknown; whileDrag?: unknown; animate?: unknown; transition?: unknown }) => (
+      div: ({
+        children,
+        style,
+        drag,
+        role,
+        'aria-label': ariaLabel,
+        'aria-grabbed': ariaGrabbed,
+        tabIndex,
+        onDragEnd: _ode,
+        dragConstraints: _dc,
+        dragElastic: _de,
+        whileDrag: _wd,
+        animate: _an,
+        transition: _tr,
+        ...rest
+      }: React.HTMLAttributes<HTMLDivElement> & {
+        drag?: boolean
+        onDragEnd?: unknown
+        dragConstraints?: unknown
+        dragElastic?: unknown
+        whileDrag?: unknown
+        animate?: unknown
+        transition?: unknown
+      }) => (
         <div
           style={style}
           role={role}
@@ -41,51 +64,51 @@ const mockUser: UserOfficeData = {
 const canvasRef = createRef<HTMLDivElement>()
 
 describe('HumanAvatar', () => {
-  it('exibe as iniciais do usuário', () => {
+  it('shows user initials', () => {
     render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
     expect(screen.getByText('AL')).toBeTruthy()
   })
 
-  it('exibe o nome do usuário', () => {
+  it('shows user name', () => {
     render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
     expect(screen.getByText('Alice Lima')).toBeTruthy()
   })
 
-  it('exibe badge YOU quando isMe=true', () => {
+  it('shows YOU badge when isMe=true', () => {
     render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
     expect(screen.getByText('you')).toBeTruthy()
   })
 
-  it('não exibe badge YOU quando isMe=false', () => {
+  it('does not show YOU badge when isMe=false', () => {
     render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
     expect(screen.queryByText('you')).toBeNull()
   })
 
-  it('tem drag ativo apenas quando isMe=true', () => {
+  it('has drag active only when isMe=true', () => {
     const { container } = render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
     const el = container.firstChild as HTMLElement
     expect(el.getAttribute('data-drag')).toBe('true')
   })
 
-  it('não tem drag quando isMe=false', () => {
+  it('has no drag when isMe=false', () => {
     const { container } = render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
     const el = container.firstChild as HTMLElement
     expect(el.getAttribute('data-drag')).toBeNull()
   })
 
-  it('tem role=button e aria-label quando isMe=true', () => {
+  it('has role=button and aria-label when isMe=true', () => {
     render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
     const btn = screen.getByRole('button')
     expect(btn).toBeTruthy()
     expect(btn.getAttribute('aria-label')).toContain('Alice Lima')
   })
 
-  it('não tem role=button quando isMe=false', () => {
+  it('has no role=button when isMe=false', () => {
     render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
     expect(screen.queryByRole('button')).toBeNull()
   })
 
-  it('tem aria-label descrevendo o usuário quando isMe=false', () => {
+  it('has aria-label describing the user when isMe=false', () => {
     const { container } = render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
     const el = container.firstChild as HTMLElement
     expect(el.getAttribute('aria-label')).toContain('Alice Lima')

--- a/src/components/HumanAvatar.tsx
+++ b/src/components/HumanAvatar.tsx
@@ -6,19 +6,15 @@ import type { UserOfficeData } from '../hooks/useOfficeState'
 
 interface HumanAvatarProps {
   user: UserOfficeData
-  /** Indica se este é o avatar do próprio usuário (draggable) */
+  /** Whether this is the current user's own avatar (draggable) */
   isMe: boolean
-  /** Ref do elemento canvas para calcular constraints de drag */
+  /** Ref to the canvas element for calculating drag constraints */
   canvasRef: React.RefObject<HTMLDivElement | null>
 }
 
 const EMIT_DEBOUNCE_MS = 100
 
-export const HumanAvatar = memo(function HumanAvatar({
-  user,
-  isMe,
-  canvasRef,
-}: HumanAvatarProps) {
+export const HumanAvatar = memo(function HumanAvatar({ user, isMe, canvasRef }: HumanAvatarProps) {
   const color = hashColor(user.userId)
   const label = initials(user.name)
   const lastEmitAt = useRef(0)
@@ -34,20 +30,20 @@ export const HumanAvatar = memo(function HumanAvatar({
       const x = toPercent(info.point.x - rect.left, rect.width)
       const y = toPercent(info.point.y - rect.top, rect.height)
 
-      // Debounce para evitar flood de eventos
+      // Debounce to avoid event flooding
       const now = Date.now()
       if (now - lastEmitAt.current < EMIT_DEBOUNCE_MS) return
       lastEmitAt.current = now
 
       getSocket().emit('office:user:move', { x, y })
     },
-    [isMe, canvasRef],
+    [isMe, canvasRef]
   )
 
   return (
     <motion.div
       role={isMe ? 'button' : undefined}
-      aria-label={isMe ? `seu avatar: ${user.name}, arraste para mover` : `usuário ${user.name}`}
+      aria-label={isMe ? `your avatar: ${user.name}, drag to move` : `user ${user.name}`}
       aria-grabbed={isMe ? false : undefined}
       tabIndex={isMe ? 0 : undefined}
       style={{
@@ -63,7 +59,7 @@ export const HumanAvatar = memo(function HumanAvatar({
         userSelect: 'none',
         zIndex: isMe ? 20 : 10,
       }}
-      // Animar suavemente para nova posição (outros usuários)
+      // Smoothly animate to new position (other users)
       animate={{ left: `${user.x}%`, top: `${user.y}%` }}
       transition={{ type: 'spring', stiffness: 200, damping: 25 }}
       drag={isMe || undefined}
@@ -72,7 +68,7 @@ export const HumanAvatar = memo(function HumanAvatar({
       whileDrag={{ scale: 1.12, cursor: 'grabbing', zIndex: 1000 }}
       onDragEnd={handleDragEnd}
     >
-      {/* Avatar circular */}
+      {/* Circular avatar */}
       <div
         style={{
           width: 32,
@@ -93,7 +89,7 @@ export const HumanAvatar = memo(function HumanAvatar({
         {label}
       </div>
 
-      {/* Badge YOU + nome */}
+      {/* YOU badge + name */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
         {isMe && (
           <span

--- a/src/components/OfficeCanvas.test.tsx
+++ b/src/components/OfficeCanvas.test.tsx
@@ -4,44 +4,44 @@ import { OfficeCanvas } from './OfficeCanvas'
 import { OFFICE_ZONES } from '../data/office-layout'
 
 describe('OfficeCanvas', () => {
-  it('renderiza todas as zonas', () => {
+  it('renders all zones', () => {
     render(<OfficeCanvas connectionStatus="connected" />)
     for (const zone of OFFICE_ZONES) {
       expect(document.querySelector(`[data-zone-id="${zone.id}"]`)).toBeTruthy()
     }
   })
 
-  it('renderiza o HUD com status connected', () => {
+  it('renders HUD with connected status', () => {
     render(<OfficeCanvas connectionStatus="connected" />)
     expect(screen.getByText('online')).toBeTruthy()
   })
 
-  it('renderiza o HUD com status error', () => {
+  it('renders HUD with error status', () => {
     render(<OfficeCanvas connectionStatus="error" />)
-    expect(screen.getByText('erro')).toBeTruthy()
+    expect(screen.getByText('error')).toBeTruthy()
   })
 
-  it('exibe contagem de agentes', () => {
+  it('shows agent count', () => {
     render(<OfficeCanvas connectionStatus="connected" agentCount={3} />)
     expect(screen.getByText('3 agents')).toBeTruthy()
   })
 
-  it('exibe "agent" no singular', () => {
+  it('shows "agent" in singular', () => {
     render(<OfficeCanvas connectionStatus="connected" agentCount={1} />)
     expect(screen.getByText('1 agent')).toBeTruthy()
   })
 
-  it('não exibe humans quando humanCount é 0', () => {
+  it('does not show humans when humanCount is 0', () => {
     render(<OfficeCanvas connectionStatus="connected" humanCount={0} />)
     expect(screen.queryByText(/human/)).toBeNull()
   })
 
-  it('exibe humans quando humanCount > 0', () => {
+  it('shows humans when humanCount > 0', () => {
     render(<OfficeCanvas connectionStatus="connected" humanCount={2} />)
     expect(screen.getByText('2 humans')).toBeTruthy()
   })
 
-  it('renderiza children dentro do canvas', () => {
+  it('renders children inside the canvas', () => {
     render(
       <OfficeCanvas connectionStatus="connected">
         <div data-testid="avatar">Agent Avatar</div>
@@ -50,7 +50,7 @@ describe('OfficeCanvas', () => {
     expect(screen.getByTestId('avatar')).toBeTruthy()
   })
 
-  it('usa cor de fundo estática definida em COLORS', () => {
+  it('uses static background color defined in COLORS', () => {
     const { container } = render(<OfficeCanvas connectionStatus="connected" />)
     const canvas = container.firstChild as HTMLElement
     expect(canvas.style.background).toBeTruthy()

--- a/src/components/OfficeCanvas.tsx
+++ b/src/components/OfficeCanvas.tsx
@@ -10,7 +10,7 @@ interface OfficeCanvasProps {
   connectionStatus: ConnectionStatus
   agentCount?: number
   humanCount?: number
-  /** Ref para o elemento raiz — usado como dragConstraints pelo HumanAvatar */
+  /** Ref to the root element — used as dragConstraints by HumanAvatar */
   canvasRef?: RefObject<HTMLDivElement | null>
 }
 
@@ -45,18 +45,18 @@ export function OfficeCanvas({
         fontFamily: 'JetBrains Mono, monospace',
       }}
     >
-      {/* Grid decorativo */}
+      {/* Decorative grid */}
       <div style={gridStyle} />
 
-      {/* Zonas do escritório */}
+      {/* Office zones */}
       {OFFICE_ZONES.map((zone) => (
         <OfficeRoom key={zone.id} zone={zone} />
       ))}
 
-      {/* Avatares (agents + humans) — passados como children */}
+      {/* Avatars (agents + humans) — passed as children */}
       {children}
 
-      {/* HUD: status de conexão + contagem */}
+      {/* HUD: connection status + counts */}
       <OfficeHUD
         connectionStatus={connectionStatus}
         agentCount={agentCount}

--- a/src/components/OfficeHUD.test.tsx
+++ b/src/components/OfficeHUD.test.tsx
@@ -3,32 +3,32 @@ import { render, screen } from '@testing-library/react'
 import { OfficeHUD } from './OfficeHUD'
 
 describe('OfficeHUD', () => {
-  it('exibe status de conexão', () => {
+  it('shows connection status', () => {
     render(<OfficeHUD connectionStatus="connected" />)
     expect(screen.getByText('online')).toBeTruthy()
   })
 
-  it('exibe contagem de agentes', () => {
+  it('shows agent count', () => {
     render(<OfficeHUD connectionStatus="connected" agentCount={3} />)
     expect(screen.getByText('3 agents')).toBeTruthy()
   })
 
-  it('exibe singular para 1 agente', () => {
+  it('shows singular for 1 agent', () => {
     render(<OfficeHUD connectionStatus="connected" agentCount={1} />)
     expect(screen.getByText('1 agent')).toBeTruthy()
   })
 
-  it('não exibe humanos quando humanCount=0', () => {
+  it('does not show humans when humanCount=0', () => {
     render(<OfficeHUD connectionStatus="connected" humanCount={0} />)
     expect(screen.queryByText(/human/i)).toBeNull()
   })
 
-  it('exibe contagem de humanos quando humanCount>0', () => {
+  it('shows human count when humanCount>0', () => {
     render(<OfficeHUD connectionStatus="connected" humanCount={2} />)
     expect(screen.getByText('2 humans')).toBeTruthy()
   })
 
-  it('status role="status" presente', () => {
+  it('status role="status" is present', () => {
     render(<OfficeHUD connectionStatus="connecting" />)
     expect(screen.getByRole('status')).toBeTruthy()
   })

--- a/src/components/OfficeHUD.tsx
+++ b/src/components/OfficeHUD.tsx
@@ -36,7 +36,7 @@ export const OfficeHUD = memo(function OfficeHUD({
         color: COLORS.label,
       }}
     >
-      {/* Status conexão */}
+      {/* Connection status */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
         <span
           aria-label={`status: ${label}`}
@@ -54,7 +54,7 @@ export const OfficeHUD = memo(function OfficeHUD({
 
       <span style={{ color: COLORS.separator }}>│</span>
 
-      {/* Agentes online */}
+      {/* Online agents */}
       <span>
         {agentCount} agent{agentCount !== 1 ? 's' : ''}
       </span>

--- a/src/components/OfficeRoom.test.tsx
+++ b/src/components/OfficeRoom.test.tsx
@@ -12,26 +12,26 @@ const mockZone: Zone = {
   width: 30,
   height: 25,
   color: '#1a1a2e',
-  description: 'Zona de teste',
+  description: 'Test zone',
 }
 
 describe('OfficeRoom', () => {
-  it('renderiza com data-zone-id correto', () => {
+  it('renders with correct data-zone-id', () => {
     render(<OfficeRoom zone={mockZone} />)
     expect(document.querySelector('[data-zone-id="test-zone"]')).toBeTruthy()
   })
 
-  it('exibe o ícone da zona', () => {
+  it('shows zone icon', () => {
     render(<OfficeRoom zone={mockZone} />)
     expect(screen.getByText('🧪')).toBeTruthy()
   })
 
-  it('exibe o label da zona', () => {
+  it('shows zone label', () => {
     render(<OfficeRoom zone={mockZone} />)
     expect(screen.getByText('Test Zone')).toBeTruthy()
   })
 
-  it('posiciona a zona com as coordenadas corretas', () => {
+  it('positions zone with correct coordinates', () => {
     render(<OfficeRoom zone={mockZone} />)
     const el = document.querySelector('[data-zone-id="test-zone"]') as HTMLElement
     expect(el.style.left).toBe('10%')
@@ -40,7 +40,7 @@ describe('OfficeRoom', () => {
     expect(el.style.height).toBe('25%')
   })
 
-  it('aplica a cor de fundo da zona (zone.color)', () => {
+  it('applies zone background color (zone.color)', () => {
     render(<OfficeRoom zone={mockZone} />)
     const el = document.querySelector('[data-zone-id="test-zone"]') as HTMLElement
     expect(el.style.background).toBeTruthy()

--- a/src/components/OfficeRoom.tsx
+++ b/src/components/OfficeRoom.tsx
@@ -22,7 +22,7 @@ export const OfficeRoom = memo(function OfficeRoom({ zone }: OfficeRoomProps) {
         overflow: 'hidden',
       }}
     >
-      {/* Header da zona */}
+      {/* Zone header */}
       <div
         style={{
           display: 'flex',

--- a/src/components/OnlineUsersList.test.tsx
+++ b/src/components/OnlineUsersList.test.tsx
@@ -41,47 +41,45 @@ const mockUsers: UserOfficeData[] = [
 ]
 
 describe('OnlineUsersList', () => {
-  it('não renderiza quando lista está vazia', () => {
-    const { container } = render(
-      <OnlineUsersList users={[]} mySocketId={null} />,
-    )
+  it('does not render when list is empty', () => {
+    const { container } = render(<OnlineUsersList users={[]} mySocketId={null} />)
     expect(container.firstChild).toBeNull()
   })
 
-  it('exibe cabeçalho com contagem de usuários', () => {
+  it('shows header with user count', () => {
     render(<OnlineUsersList users={mockUsers} mySocketId={null} />)
     expect(screen.getByText(/online · 2/i)).toBeTruthy()
   })
 
-  it('exibe nome de todos os usuários', () => {
+  it('shows all user names', () => {
     render(<OnlineUsersList users={mockUsers} mySocketId={null} />)
     expect(screen.getByText('Alice Lima')).toBeTruthy()
     expect(screen.getByText('Bob Silva')).toBeTruthy()
   })
 
-  it('exibe badge you apenas para o próprio usuário', () => {
+  it('shows you badge only for own user', () => {
     render(<OnlineUsersList users={mockUsers} mySocketId="sock-1" />)
     expect(screen.getByText('you')).toBeTruthy()
   })
 
-  it('não exibe badge you quando mySocketId não corresponde', () => {
+  it('does not show you badge when mySocketId does not match', () => {
     render(<OnlineUsersList users={mockUsers} mySocketId="sock-999" />)
     expect(screen.queryByText('you')).toBeNull()
   })
 
-  it('tem role list e aria-label para acessibilidade', () => {
+  it('has list role and aria-label for accessibility', () => {
     render(<OnlineUsersList users={mockUsers} mySocketId={null} />)
-    const list = screen.getByRole('list', { name: /usuários online/i })
+    const list = screen.getByRole('list', { name: /online users/i })
     expect(list).toBeTruthy()
   })
 
-  it('exibe as iniciais de cada usuário', () => {
+  it('shows initials of each user', () => {
     render(<OnlineUsersList users={mockUsers} mySocketId={null} />)
     expect(screen.getByText('AL')).toBeTruthy()
     expect(screen.getByText('BS')).toBeTruthy()
   })
 
-  it('exibe contagem correta com 1 usuário', () => {
+  it('shows correct count with 1 user', () => {
     render(<OnlineUsersList users={[mockUsers[0]]} mySocketId={null} />)
     expect(screen.getByText(/online · 1/i)).toBeTruthy()
   })

--- a/src/components/OnlineUsersList.tsx
+++ b/src/components/OnlineUsersList.tsx
@@ -14,13 +14,7 @@ const ITEM_VARIANTS = {
   exit: { opacity: 0, x: -12, transition: { duration: 0.15 } },
 }
 
-const UserRow = memo(function UserRow({
-  user,
-  isMe,
-}: {
-  user: UserOfficeData
-  isMe: boolean
-}) {
+const UserRow = memo(function UserRow({ user, isMe }: { user: UserOfficeData; isMe: boolean }) {
   const color = user.userId ? hashColor(user.userId) : '#6b7280'
   const label = user.name ? initials(user.name) : '?'
 
@@ -38,7 +32,7 @@ const UserRow = memo(function UserRow({
         padding: '3px 0',
       }}
     >
-      {/* Avatar circular mini */}
+      {/* Mini circular avatar */}
       <div
         aria-hidden="true"
         style={{
@@ -59,7 +53,7 @@ const UserRow = memo(function UserRow({
         {label}
       </div>
 
-      {/* Nome */}
+      {/* Name */}
       <span
         style={{
           fontSize: 10,
@@ -73,9 +67,7 @@ const UserRow = memo(function UserRow({
         title={user.name}
       >
         {user.name}
-        {isMe && (
-          <span style={{ color, opacity: 0.7, marginLeft: 4, fontSize: 8 }}>you</span>
-        )}
+        {isMe && <span style={{ color, opacity: 0.7, marginLeft: 4, fontSize: 8 }}>you</span>}
       </span>
     </motion.div>
   )
@@ -90,7 +82,7 @@ export const OnlineUsersList = memo(function OnlineUsersList({
   return (
     <div
       role="list"
-      aria-label="usuários online"
+      aria-label="online users"
       style={{
         position: 'fixed',
         top: 16,
@@ -106,7 +98,7 @@ export const OnlineUsersList = memo(function OnlineUsersList({
         zIndex: 50,
       }}
     >
-      {/* Cabeçalho */}
+      {/* Header */}
       <div
         style={{
           fontSize: 9,
@@ -121,9 +113,9 @@ export const OnlineUsersList = memo(function OnlineUsersList({
         online · {users.length}
       </div>
 
-      {/* Lista com AnimatePresence para animações de join/leave */}
+      {/* List with AnimatePresence for join/leave animations */}
       <AnimatePresence initial={false}>
-        {users.map(user => (
+        {users.map((user) => (
           <div key={user.socketId} role="listitem">
             <UserRow user={user} isMe={user.socketId === mySocketId} />
           </div>

--- a/src/components/SpeechBubble.test.tsx
+++ b/src/components/SpeechBubble.test.tsx
@@ -3,31 +3,31 @@ import { render, screen } from '@testing-library/react'
 import { SpeechBubble } from './SpeechBubble'
 
 describe('SpeechBubble', () => {
-  it('não renderiza nada quando text é null', () => {
+  it('renders nothing when text is null', () => {
     const { container } = render(<SpeechBubble text={null} color="#8b5cf6" />)
     expect(container.firstChild).toBeNull()
   })
 
-  it('renderiza o texto quando fornecido', () => {
-    render(<SpeechBubble text="Implementando feature" color="#8b5cf6" />)
-    expect(screen.getByText('Implementando feature')).toBeTruthy()
+  it('renders the text when provided', () => {
+    render(<SpeechBubble text="Implementing feature" color="#8b5cf6" />)
+    expect(screen.getByText('Implementing feature')).toBeTruthy()
   })
 
-  it('trunca texto maior que 40 chars com reticências', () => {
+  it('truncates text longer than 40 chars with ellipsis', () => {
     const longText = 'A'.repeat(50)
     render(<SpeechBubble text={longText} color="#8b5cf6" />)
     const el = screen.getByText(`${'A'.repeat(40)}…`)
     expect(el).toBeTruthy()
   })
 
-  it('não trunca texto com exatamente 40 chars', () => {
+  it('does not truncate text with exactly 40 chars', () => {
     const text = 'A'.repeat(40)
     render(<SpeechBubble text={text} color="#8b5cf6" />)
     expect(screen.getByText(text)).toBeTruthy()
   })
 
-  it('renderiza a seta apontando para baixo', () => {
-    render(<SpeechBubble text="teste" color="#8b5cf6" />)
+  it('renders the downward-pointing arrow', () => {
+    render(<SpeechBubble text="test" color="#8b5cf6" />)
     expect(screen.getByTestId('speech-arrow')).toBeTruthy()
   })
 })

--- a/src/components/SpeechBubble.tsx
+++ b/src/components/SpeechBubble.tsx
@@ -53,7 +53,7 @@ export const SpeechBubble = memo(function SpeechBubble({ text, color }: SpeechBu
           }}
         >
           {truncated}
-          {/* Seta apontando para baixo */}
+          {/* Downward-pointing arrow */}
           <span
             data-testid="speech-arrow"
             style={{

--- a/src/constants/agent.ts
+++ b/src/constants/agent.ts
@@ -1,17 +1,17 @@
 /**
- * Cores por agente — chaves são os IDs reais da API (GET /api/dashboard/agents).
- * A ordem define o índice de posicionamento anti-sobreposição (0, 1, 2).
+ * Colors per agent — keys are the real API IDs (GET /api/dashboard/agents).
+ * Order defines the anti-overlap positioning index (0, 1, 2).
  */
 export const AGENT_COLORS = {
-  'rx-architect':    '#8b5cf6', // violet  — Claude
-  'rx-backend':      '#10b981', // emerald — Gemini
+  'rx-architect': '#8b5cf6', // violet  — Claude
+  'rx-backend': '#10b981', // emerald — Gemini
   'rx-orchestrator': '#f59e0b', // amber   — OpenCode
 } as const
 
-/** Cor usada quando o agente não está mapeado em AGENT_COLORS */
+/** Color used when the agent is not mapped in AGENT_COLORS */
 export const DEFAULT_AGENT_COLOR = '#6b7280'
 
-/** Retorna a cor do agente pelo ID, ou DEFAULT_AGENT_COLOR como fallback */
+/** Returns the agent color by ID, or DEFAULT_AGENT_COLOR as fallback */
 export function getAgentColor(agentId: string): string {
   return agentId in AGENT_COLORS
     ? AGENT_COLORS[agentId as keyof typeof AGENT_COLORS]
@@ -19,13 +19,13 @@ export function getAgentColor(agentId: string): string {
 }
 
 /**
- * Labels de exibição para cada status de agente retornado pelo backend MAGO.
- * Usar como fallback quando o status não está mapeado: `AGENT_STATUS_LABEL[s] ?? s`
+ * Display labels for each agent status returned by the MAGO backend.
+ * Use as fallback when the status is not mapped: `AGENT_STATUS_LABEL[s] ?? s`
  */
 export const AGENT_STATUS_LABEL: Record<string, string> = {
-  idle:     'idle',
-  working:  'working',
+  idle: 'idle',
+  working: 'working',
   thinking: 'thinking',
-  blocked:  'blocked',
-  offline:  'offline',
+  blocked: 'blocked',
+  offline: 'offline',
 }

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -9,9 +9,9 @@ export const STATUS_COLOR: Record<ConnectionStatus, string> = {
 }
 
 export const STATUS_LABEL: Record<ConnectionStatus, string> = {
-  connecting: 'conectando',
+  connecting: 'connecting',
   connected: 'online',
-  reconnecting: 'reconectando',
+  reconnecting: 'reconnecting',
   disconnected: 'offline',
-  error: 'erro',
+  error: 'error',
 }

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -1,4 +1,4 @@
-/** Paleta de cores estática do mago-office */
+/** Static color palette for mago-office */
 export const COLORS = {
   bg: '#0d1117',
   grid: '#1f2937',

--- a/src/data/office-layout.test.ts
+++ b/src/data/office-layout.test.ts
@@ -10,11 +10,11 @@ import {
 } from './office-layout'
 
 describe('OFFICE_ZONES', () => {
-  it('tem 6 zonas definidas', () => {
+  it('has 6 defined zones', () => {
     expect(OFFICE_ZONES).toHaveLength(6)
   })
 
-  it('todas as zonas têm campos obrigatórios', () => {
+  it('all zones have required fields', () => {
     for (const zone of OFFICE_ZONES) {
       expect(zone.id).toBeTruthy()
       expect(zone.label).toBeTruthy()
@@ -27,12 +27,12 @@ describe('OFFICE_ZONES', () => {
     }
   })
 
-  it('ids são únicos', () => {
-    const ids = OFFICE_ZONES.map(z => z.id)
+  it('ids are unique', () => {
+    const ids = OFFICE_ZONES.map((z) => z.id)
     expect(new Set(ids).size).toBe(ids.length)
   })
 
-  it('zonas não saem dos limites (x + width <= 100)', () => {
+  it('zones do not exceed bounds (x + width <= 100)', () => {
     for (const zone of OFFICE_ZONES) {
       expect(zone.x + zone.width).toBeLessThanOrEqual(100)
     }
@@ -40,20 +40,20 @@ describe('OFFICE_ZONES', () => {
 })
 
 describe('ZONE_BY_ID', () => {
-  it('resolve zona pelo id', () => {
+  it('resolves zone by id', () => {
     expect(ZONE_BY_ID['dev-zone'].label).toBe('Dev Zone')
     expect(ZONE_BY_ID['lobby'].icon).toBe('🚪')
   })
 })
 
 describe('getAgentColor', () => {
-  it('retorna cor correta para agentes conhecidos', () => {
+  it('returns correct color for known agents', () => {
     expect(getAgentColor('rx-architect')).toBe(AGENT_COLORS['rx-architect'])
     expect(getAgentColor('rx-backend')).toBe(AGENT_COLORS['rx-backend'])
     expect(getAgentColor('rx-orchestrator')).toBe(AGENT_COLORS['rx-orchestrator'])
   })
 
-  it('retorna cor default para agente desconhecido', () => {
+  it('returns default color for unknown agent', () => {
     expect(getAgentColor('agent-99')).toBe(DEFAULT_AGENT_COLOR)
   })
 })
@@ -61,7 +61,7 @@ describe('getAgentColor', () => {
 describe('getAgentZone', () => {
   it('idle → coffee-corner', () => {
     expect(getAgentZone('idle')).toBe('coffee-corner')
-    expect(getAgentZone('idle', 'implementando feature')).toBe('coffee-corner')
+    expect(getAgentZone('idle', 'implementing feature')).toBe('coffee-corner')
   })
 
   it('offline → lobby', () => {
@@ -73,42 +73,42 @@ describe('getAgentZone', () => {
   })
 
   it('working + review action → review-room', () => {
-    expect(getAgentZone('working', 'fazendo review do PR')).toBe('review-room')
+    expect(getAgentZone('working', 'doing PR review')).toBe('review-room')
     expect(getAgentZone('thinking', 'revisando código')).toBe('review-room')
     expect(getAgentZone('working', 'aprovando PR #42')).toBe('review-room')
   })
 
   it('working + planning action → planning-board', () => {
-    expect(getAgentZone('working', 'criando task no backlog')).toBe('planning-board')
+    expect(getAgentZone('working', 'creating task in backlog')).toBe('planning-board')
     expect(getAgentZone('thinking', 'sprint planning')).toBe('planning-board')
   })
 
   it('working + analysis action → analysis-area', () => {
-    expect(getAgentZone('working', 'analisando bug')).toBe('analysis-area')
-    expect(getAgentZone('thinking', 'debugging fluxo')).toBe('analysis-area')
+    expect(getAgentZone('working', 'analyzing bug')).toBe('analysis-area')
+    expect(getAgentZone('thinking', 'debugging flow')).toBe('analysis-area')
     expect(getAgentZone('working', 'inspect memory leak')).toBe('analysis-area')
   })
 
-  it('working sem action específica → dev-zone', () => {
+  it('working with no specific action → dev-zone', () => {
     expect(getAgentZone('working')).toBe('dev-zone')
-    expect(getAgentZone('working', 'implementando feature X')).toBe('dev-zone')
+    expect(getAgentZone('working', 'implementing feature X')).toBe('dev-zone')
     expect(getAgentZone('thinking', '')).toBe('dev-zone')
   })
 
-  it('status null/undefined → lobby (safe default)', () => {
+  it('null/undefined status → lobby (safe default)', () => {
     expect(getAgentZone(null)).toBe('lobby')
     expect(getAgentZone(undefined)).toBe('lobby')
     expect(getAgentZone('')).toBe('lobby')
   })
 
-  it('status desconhecido → dev-zone', () => {
+  it('unknown status → dev-zone', () => {
     expect(getAgentZone('busy')).toBe('dev-zone')
     expect(getAgentZone('away')).toBe('dev-zone')
   })
 })
 
 describe('getAgentPosition', () => {
-  it('calcula posição dentro da zona para agente-1 (index 0)', () => {
+  it('calculates position within zone for agent-1 (index 0)', () => {
     // dev-zone: x=2, y=5, width=28, height=30
     // offset[0] = { x:25, y:40 } → x = 2 + 28*0.25 = 9, y = 5 + 30*0.40 = 17
     const pos = getAgentPosition('dev-zone', 0)
@@ -116,7 +116,7 @@ describe('getAgentPosition', () => {
     expect(pos.y).toBe(17)
   })
 
-  it('calcula posição dentro da zona para agente-2 (index 1)', () => {
+  it('calculates position within zone for agent-2 (index 1)', () => {
     // dev-zone: x=2, y=5, width=28, height=30
     // offset[1] = { x:50, y:40 } → x = 2 + 28*0.50 = 16, y = 5 + 30*0.40 = 17
     const pos = getAgentPosition('dev-zone', 1)
@@ -124,7 +124,7 @@ describe('getAgentPosition', () => {
     expect(pos.y).toBe(17)
   })
 
-  it('calcula posição dentro da zona para agente-3 (index 2)', () => {
+  it('calculates position within zone for agent-3 (index 2)', () => {
     // dev-zone: x=2, y=5, width=28, height=30
     // offset[2] = { x:75, y:40 } → x = 2 + 28*0.75 = 23, y = 5 + 30*0.40 = 17
     const pos = getAgentPosition('dev-zone', 2)
@@ -132,20 +132,20 @@ describe('getAgentPosition', () => {
     expect(pos.y).toBe(17)
   })
 
-  it('retorna posição central para zona desconhecida', () => {
-    const pos = getAgentPosition('zona-inexistente', 0)
+  it('returns center position for unknown zone', () => {
+    const pos = getAgentPosition('nonexistent-zone', 0)
     expect(pos).toEqual({ x: 50, y: 50 })
   })
 
-  it('usa offset default para índice fora do range', () => {
-    // index 99 não existe → offset default { x:50, y:50 }
+  it('uses default offset for out-of-range index', () => {
+    // index 99 does not exist → default offset { x:50, y:50 }
     // dev-zone: x=2, y=5, width=28, height=30 → x=2+14=16, y=5+15=20
     const pos = getAgentPosition('dev-zone', 99)
     expect(pos.x).toBe(16)
     expect(pos.y).toBe(20)
   })
 
-  it('cada agente tem posição horizontal distinta na mesma zona', () => {
+  it('each agent has a distinct horizontal position in the same zone', () => {
     const p0 = getAgentPosition('coffee-corner', 0)
     const p1 = getAgentPosition('coffee-corner', 1)
     const p2 = getAgentPosition('coffee-corner', 2)

--- a/src/data/office-layout.ts
+++ b/src/data/office-layout.ts
@@ -2,11 +2,11 @@ export interface Zone {
   id: string
   label: string
   icon: string
-  x: number       // % from left
-  y: number       // % from top
-  width: number   // % width
-  height: number  // % height
-  color: string   // background (dark theme)
+  x: number // % from left
+  y: number // % from top
+  width: number // % width
+  height: number // % height
+  color: string // background (dark theme)
   description: string
 }
 
@@ -15,60 +15,79 @@ export const OFFICE_ZONES: Zone[] = [
     id: 'dev-zone',
     label: 'Dev Zone',
     icon: '⚡',
-    x: 2, y: 5, width: 28, height: 30,
+    x: 2,
+    y: 5,
+    width: 28,
+    height: 30,
     color: '#1e1b4b',
-    description: 'Implementação e desenvolvimento',
+    description: 'Implementation and development',
   },
   {
     id: 'review-room',
     label: 'Review Room',
     icon: '👁',
-    x: 34, y: 5, width: 28, height: 30,
+    x: 34,
+    y: 5,
+    width: 28,
+    height: 30,
     color: '#1a2035',
-    description: 'Code review e análise de qualidade',
+    description: 'Code review and quality analysis',
   },
   {
     id: 'planning-board',
     label: 'Planning Board',
     icon: '📋',
-    x: 66, y: 5, width: 30, height: 30,
+    x: 66,
+    y: 5,
+    width: 30,
+    height: 30,
     color: '#1f1635',
-    description: 'Sprint planning e task management',
+    description: 'Sprint planning and task management',
   },
   {
     id: 'analysis-area',
     label: 'Analysis Area',
     icon: '🔍',
-    x: 2, y: 42, width: 44, height: 30,
+    x: 2,
+    y: 42,
+    width: 44,
+    height: 30,
     color: '#0f2027',
-    description: 'Análise de problemas e edge cases',
+    description: 'Problem analysis and edge cases',
   },
   {
     id: 'coffee-corner',
     label: 'Coffee Corner',
     icon: '☕',
-    x: 50, y: 42, width: 46, height: 30,
+    x: 50,
+    y: 42,
+    width: 46,
+    height: 30,
     color: '#1a0f0f',
-    description: 'Agentes em idle descansam aqui',
+    description: 'Idle agents rest here',
   },
   {
     id: 'lobby',
     label: 'Lobby',
     icon: '🚪',
-    x: 2, y: 78, width: 94, height: 18,
+    x: 2,
+    y: 78,
+    width: 94,
+    height: 18,
     color: '#0d1117',
-    description: 'Entrada — humanos e agentes offline',
+    description: 'Entrance — humans and offline agents',
   },
 ]
 
-export const ZONE_BY_ID = Object.fromEntries(
-  OFFICE_ZONES.map(z => [z.id, z]),
-) as Record<string, Zone>
+export const ZONE_BY_ID = Object.fromEntries(OFFICE_ZONES.map((z) => [z.id, z])) as Record<
+  string,
+  Zone
+>
 
 /**
- * Offsets dentro de uma zona por índice do agente (0-based).
- * Valores em % relativo à zona (0–100).
- * Garante anti-sobreposição para até 3 agentes.
+ * Offsets within a zone by agent index (0-based).
+ * Values in % relative to the zone (0–100).
+ * Guarantees anti-overlap for up to 3 agents.
  */
 const AGENT_ZONE_OFFSETS = [
   { x: 25, y: 40 }, // rx-architect (Claude)
@@ -86,11 +105,11 @@ export interface AgentPosition {
 }
 
 /**
- * Calcula a posição absoluta (% do canvas) de um agente dentro de sua zona,
- * usando o índice do agente para evitar sobreposição.
+ * Calculates the absolute position (% of canvas) of an agent within its zone,
+ * using the agent index to avoid overlap.
  *
- * @param zoneId   ID da zona onde o agente está
- * @param agentIndex  Índice 0-based do agente (0=agent-1, 1=agent-2, 2=agent-3)
+ * @param zoneId      ID of the zone where the agent is located
+ * @param agentIndex  0-based agent index (0=agent-1, 1=agent-2, 2=agent-3)
  */
 export function getAgentPosition(zoneId: string, agentIndex: number): AgentPosition {
   const zone = ZONE_BY_ID[zoneId]
@@ -104,18 +123,18 @@ export function getAgentPosition(zoneId: string, agentIndex: number): AgentPosit
   }
 }
 
-// Re-exportado de constants/agent para manter compatibilidade com imports existentes
+// Re-exported from constants/agent to maintain compatibility with existing imports
 export { AGENT_COLORS, DEFAULT_AGENT_COLOR, getAgentColor } from '../constants/agent'
 
 /**
- * Statuses suportados pelo MAGO backend:
+ * Statuses supported by the MAGO backend:
  *   idle      → coffee-corner
  *   offline   → lobby
  *   blocked   → lobby
- *   working   → zona baseada em lastAction
- *   thinking  → zona baseada em lastAction
+ *   working   → zone based on lastAction
+ *   thinking  → zone based on lastAction
  *
- * Outros valores (ex: undefined, null, desconhecido) → lobby (safe default)
+ * Other values (e.g. undefined, null, unknown) → lobby (safe default)
  */
 export function getAgentZone(status: string | null | undefined, lastAction = ''): string {
   if (!status) return 'lobby'
@@ -123,16 +142,26 @@ export function getAgentZone(status: string | null | undefined, lastAction = '')
   if (status === 'idle') return 'coffee-corner'
   if (status === 'offline' || status === 'blocked') return 'lobby'
 
-  // Para working/thinking: usar lastAction para refinar a zona
+  // For working/thinking: use lastAction to refine the zone
   const action = lastAction.toLowerCase()
 
   if (action.includes('review') || action.includes('aprovando') || action.includes('revisando')) {
     return 'review-room'
   }
-  if (action.includes('plan') || action.includes('task') || action.includes('sprint') || action.includes('backlog')) {
+  if (
+    action.includes('plan') ||
+    action.includes('task') ||
+    action.includes('sprint') ||
+    action.includes('backlog')
+  ) {
     return 'planning-board'
   }
-  if (action.includes('analyz') || action.includes('analis') || action.includes('inspect') || action.includes('debug')) {
+  if (
+    action.includes('analyz') ||
+    action.includes('analis') ||
+    action.includes('inspect') ||
+    action.includes('debug')
+  ) {
     return 'analysis-area'
   }
 

--- a/src/hooks/useOfficeState.test.ts
+++ b/src/hooks/useOfficeState.test.ts
@@ -27,7 +27,7 @@ const mockAgents: RawAgent[] = [
     name: 'Architect',
     role: 'architect',
     status: 'idle',
-    current_task: 'Aguardando próximo ciclo',
+    current_task: 'Waiting for next cycle',
     progress: null,
     last_heartbeat: '2026-03-01T00:00:00Z',
     messages_count: 0,
@@ -37,7 +37,7 @@ const mockAgents: RawAgent[] = [
     name: 'Backend',
     role: 'backend',
     status: 'working',
-    current_task: 'implementando feature X',
+    current_task: 'implementing feature X',
     progress: null,
     last_heartbeat: '2026-03-01T00:00:01Z',
     messages_count: 2,
@@ -66,7 +66,7 @@ beforeEach(() => {
     vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockAgents),
-    }),
+    })
   )
 })
 
@@ -79,18 +79,18 @@ afterEach(() => {
 
 const { useOfficeState } = await import('./useOfficeState')
 
-describe('useOfficeState — carga inicial', () => {
-  it('começa em estado de loading e termina sem erro', async () => {
+describe('useOfficeState — initial load', () => {
+  it('starts in loading state and finishes without error', async () => {
     const { result } = renderHook(() => useOfficeState())
-    // Estado inicial: loading=true, agents vazio
+    // Initial state: loading=true, agents empty
     expect(result.current.isLoading).toBe(true)
     expect(result.current.agents).toHaveLength(0)
-    // Após fetch resolver: loading=false, agents preenchidos
+    // After fetch resolves: loading=false, agents populated
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.error).toBeNull()
   })
 
-  it('carrega agentes da API e calcula zona/posição', async () => {
+  it('loads agents from API and calculates zone/position', async () => {
     const { result } = renderHook(() => useOfficeState())
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -99,31 +99,31 @@ describe('useOfficeState — carga inicial', () => {
     expect(result.current.error).toBeNull()
   })
 
-  it('agente idle vai para coffee-corner', async () => {
+  it('idle agent goes to coffee-corner', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    const architect = result.current.agents.find(a => a.id === 'rx-architect')
+    const architect = result.current.agents.find((a) => a.id === 'rx-architect')
     expect(architect?.zoneId).toBe('coffee-corner')
   })
 
-  it('agente working sem action específica vai para dev-zone', async () => {
+  it('working agent with no specific action goes to dev-zone', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    const backend = result.current.agents.find(a => a.id === 'rx-backend')
+    const backend = result.current.agents.find((a) => a.id === 'rx-backend')
     expect(backend?.zoneId).toBe('dev-zone')
   })
 
-  it('agente thinking com review action vai para review-room', async () => {
+  it('thinking agent with review action goes to review-room', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    const orchestrator = result.current.agents.find(a => a.id === 'rx-orchestrator')
+    const orchestrator = result.current.agents.find((a) => a.id === 'rx-orchestrator')
     expect(orchestrator?.zoneId).toBe('review-room')
   })
 
-  it('agentes têm posição calculada (x e y são números)', async () => {
+  it('agents have calculated position (x and y are numbers)', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
@@ -133,15 +133,15 @@ describe('useOfficeState — carga inicial', () => {
     }
   })
 
-  it('mapeia currentTask a partir de current_task da API', async () => {
+  it('maps currentTask from API current_task', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    const backend = result.current.agents.find(a => a.id === 'rx-backend')
-    expect(backend?.currentTask).toBe('implementando feature X')
+    const backend = result.current.agents.find((a) => a.id === 'rx-backend')
+    expect(backend?.currentTask).toBe('implementing feature X')
   })
 
-  it('speechText começa como null', async () => {
+  it('speechText starts as null', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
@@ -151,12 +151,9 @@ describe('useOfficeState — carga inicial', () => {
   })
 })
 
-describe('useOfficeState — erro na API', () => {
-  it('define error e sai do loading quando fetch falha', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
-    )
+describe('useOfficeState — API error', () => {
+  it('sets error and exits loading when fetch fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
 
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -166,8 +163,8 @@ describe('useOfficeState — erro na API', () => {
   })
 })
 
-describe('useOfficeState — eventos socket', () => {
-  it('atualiza zona do agente ao receber agent:status:updated', async () => {
+describe('useOfficeState — socket events', () => {
+  it('updates agent zone when agent:status:updated is received', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
@@ -176,25 +173,25 @@ describe('useOfficeState — eventos socket', () => {
       handler?.({ agentId: 'rx-architect', status: 'working', lastAction: 'revisando PR #12' })
     })
 
-    const architect = result.current.agents.find(a => a.id === 'rx-architect')
+    const architect = result.current.agents.find((a) => a.id === 'rx-architect')
     expect(architect?.zoneId).toBe('review-room')
     expect(architect?.status).toBe('working')
   })
 
-  it('exibe speechText ao receber bus:message', async () => {
+  it('shows speechText when bus:message is received', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     act(() => {
       const handler = socketListeners.get('bus:message')
-      handler?.({ from: 'rx-backend', payload: { content: 'Iniciando análise' } })
+      handler?.({ from: 'rx-backend', payload: { content: 'Starting analysis' } })
     })
 
-    const backend = result.current.agents.find(a => a.id === 'rx-backend')
-    expect(backend?.speechText).toBe('Iniciando análise')
+    const backend = result.current.agents.find((a) => a.id === 'rx-backend')
+    expect(backend?.speechText).toBe('Starting analysis')
   })
 
-  it('bus:message sem content não altera speechText', async () => {
+  it('bus:message without content does not change speechText', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
@@ -203,12 +200,12 @@ describe('useOfficeState — eventos socket', () => {
       handler?.({ from: 'rx-backend', payload: {} })
     })
 
-    const backend = result.current.agents.find(a => a.id === 'rx-backend')
+    const backend = result.current.agents.find((a) => a.id === 'rx-backend')
     expect(backend?.speechText).toBeNull()
   })
 
-  it('limpa speechText após 5 segundos', async () => {
-    // Carregar antes de ativar fake timers (evita conflito com waitFor/fetch)
+  it('clears speechText after 5 seconds', async () => {
+    // Load before activating fake timers (avoids conflict with waitFor/fetch)
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
@@ -216,17 +213,19 @@ describe('useOfficeState — eventos socket', () => {
 
     act(() => {
       const handler = socketListeners.get('bus:message')
-      handler?.({ from: 'rx-backend', payload: { content: 'Trabalhando...' } })
+      handler?.({ from: 'rx-backend', payload: { content: 'Working...' } })
     })
 
-    expect(result.current.agents.find(a => a.id === 'rx-backend')?.speechText).toBe('Trabalhando...')
+    expect(result.current.agents.find((a) => a.id === 'rx-backend')?.speechText).toBe('Working...')
 
-    act(() => { vi.advanceTimersByTime(5000) })
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
 
-    expect(result.current.agents.find(a => a.id === 'rx-backend')?.speechText).toBeNull()
+    expect(result.current.agents.find((a) => a.id === 'rx-backend')?.speechText).toBeNull()
   })
 
-  it('adiciona usuário ao receber office:user:joined', async () => {
+  it('adds user when office:user:joined is received', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
@@ -239,12 +238,18 @@ describe('useOfficeState — eventos socket', () => {
     expect(result.current.users[0].name).toBe('Alice')
   })
 
-  it('remove usuário ao receber office:user:left', async () => {
+  it('removes user when office:user:left is received', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     act(() => {
-      socketListeners.get('office:user:joined')?.({ socketId: 'abc123', userId: 'user-1', name: 'Alice', x: 50, y: 88 })
+      socketListeners.get('office:user:joined')?.({
+        socketId: 'abc123',
+        userId: 'user-1',
+        name: 'Alice',
+        x: 50,
+        y: 88,
+      })
     })
     act(() => {
       socketListeners.get('office:user:left')?.({ socketId: 'abc123' })
@@ -253,25 +258,31 @@ describe('useOfficeState — eventos socket', () => {
     expect(result.current.users).toHaveLength(0)
   })
 
-  it('atualiza posição do usuário ao receber office:user:moved', async () => {
+  it('updates user position when office:user:moved is received', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     act(() => {
-      socketListeners.get('office:user:joined')?.({ socketId: 'abc123', userId: 'user-1', name: 'Alice', x: 50, y: 88 })
+      socketListeners.get('office:user:joined')?.({
+        socketId: 'abc123',
+        userId: 'user-1',
+        name: 'Alice',
+        x: 50,
+        y: 88,
+      })
     })
     act(() => {
       socketListeners.get('office:user:moved')?.({ socketId: 'abc123', x: 30, y: 60 })
     })
 
-    const user = result.current.users.find(u => u.socketId === 'abc123')
+    const user = result.current.users.find((u) => u.socketId === 'abc123')
     expect(user?.x).toBe(30)
     expect(user?.y).toBe(60)
   })
 })
 
 describe('useOfficeState — cleanup', () => {
-  it('remove listeners do socket ao desmontar', async () => {
+  it('removes socket listeners on unmount', async () => {
     const { result, unmount } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -1,16 +1,15 @@
 import { useEffect, useReducer, useCallback, useRef } from 'react'
 import { getSocket } from '../services/socket'
-import type { AgentStatus as SocketAgentStatus, BusMessage as SocketBusMessage, OfficeUser } from '../services/socket'
-import {
-  getAgentZone,
-  getAgentPosition,
-  getAgentColor,
-  AGENT_COLORS,
-} from '../data/office-layout'
+import type {
+  AgentStatus as SocketAgentStatus,
+  BusMessage as SocketBusMessage,
+  OfficeUser,
+} from '../services/socket'
+import { getAgentZone, getAgentPosition, getAgentColor, AGENT_COLORS } from '../data/office-layout'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-/** Shape real da API GET /api/dashboard/agents */
+/** Real shape of the GET /api/dashboard/agents API */
 export interface RawAgent {
   id: string
   name: string
@@ -22,19 +21,19 @@ export interface RawAgent {
   messages_count: number
 }
 
-/** Agente enriquecido com dados de posição calculados */
+/** Agent enriched with calculated position data */
 export interface AgentOfficeData {
   id: string
   name: string
   role: string
   status: string
-  /** current_task da API — equivalente a lastAction */
+  /** current_task from the API — equivalent to lastAction */
   currentTask: string
   zoneId: string
-  /** Posição absoluta em % do canvas */
+  /** Absolute position as % of the canvas */
   position: { x: number; y: number }
   color: string
-  /** Texto do SpeechBubble atual (nulo = oculto) */
+  /** Current SpeechBubble text (null = hidden) */
   speechText: string | null
 }
 
@@ -58,8 +57,8 @@ export interface OfficeState {
 const AGENT_IDS_ORDERED = Object.keys(AGENT_COLORS) // ['rx-architect', 'rx-backend', 'rx-orchestrator']
 
 /**
- * Determina o índice estável do agente para cálculo de offset anti-sobreposição.
- * Usa a posição do id na lista ordenada; ids desconhecidos vão para o final.
+ * Determines the stable agent index for anti-overlap offset calculation.
+ * Uses the id position in the ordered list; unknown ids go to the end.
  */
 function agentIndex(id: string): number {
   const idx = AGENT_IDS_ORDERED.indexOf(id)
@@ -107,7 +106,7 @@ function reducer(state: OfficeState, action: Action): OfficeState {
     case 'AGENT_STATUS_UPDATED':
       return {
         ...state,
-        agents: state.agents.map(a => {
+        agents: state.agents.map((a) => {
           if (a.id !== action.agentId) return a
           const raw: RawAgent = {
             id: a.id,
@@ -126,36 +125,34 @@ function reducer(state: OfficeState, action: Action): OfficeState {
     case 'AGENT_SPEECH':
       return {
         ...state,
-        agents: state.agents.map(a =>
-          a.id === action.agentId ? { ...a, speechText: action.text } : a,
+        agents: state.agents.map((a) =>
+          a.id === action.agentId ? { ...a, speechText: action.text } : a
         ),
       }
 
     case 'AGENT_SPEECH_CLEAR':
       return {
         ...state,
-        agents: state.agents.map(a =>
-          a.id === action.agentId ? { ...a, speechText: null } : a,
-        ),
+        agents: state.agents.map((a) => (a.id === action.agentId ? { ...a, speechText: null } : a)),
       }
 
     case 'USER_JOINED':
       return {
         ...state,
-        users: [...state.users.filter(u => u.socketId !== action.user.socketId), action.user],
+        users: [...state.users.filter((u) => u.socketId !== action.user.socketId), action.user],
       }
 
     case 'USER_LEFT':
       return {
         ...state,
-        users: state.users.filter(u => u.socketId !== action.socketId),
+        users: state.users.filter((u) => u.socketId !== action.socketId),
       }
 
     case 'USER_MOVED':
       return {
         ...state,
-        users: state.users.map(u =>
-          u.socketId === action.socketId ? { ...u, x: action.x, y: action.y } : u,
+        users: state.users.map((u) =>
+          u.socketId === action.socketId ? { ...u, x: action.x, y: action.y } : u
         ),
       }
 
@@ -182,7 +179,7 @@ const AGENTS_URL = `${BACKEND_URL}/api/dashboard/agents`
 export function useOfficeState(): OfficeState {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
 
-  // Manter refs de timers de speech bubble por agente para cleanup
+  // Keep refs of speech bubble timers per agent for cleanup
   const speechTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
 
   const scheduleSpeechClear = useCallback((agentId: string) => {
@@ -195,16 +192,16 @@ export function useOfficeState(): OfficeState {
     speechTimers.current.set(agentId, timer)
   }, [])
 
-  // ── Carga inicial via REST ───────────────────────────────────────────────
+  // ── Initial load via REST ────────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false
 
     fetch(AGENTS_URL)
-      .then(res => {
+      .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         return res.json() as Promise<RawAgent[]>
       })
-      .then(agents => {
+      .then((agents) => {
         if (!cancelled) dispatch({ type: 'AGENTS_LOADED', agents })
       })
       .catch((err: unknown) => {
@@ -219,7 +216,7 @@ export function useOfficeState(): OfficeState {
     }
   }, [])
 
-  // ── Socket events ────────────────────────────────────────────────────────
+  // ── Socket events ───────────────────────────────────────────────────────
   useEffect(() => {
     const socket = getSocket()
 
@@ -266,7 +263,7 @@ export function useOfficeState(): OfficeState {
     }
   }, [scheduleSpeechClear])
 
-  // ── Cleanup de timers ao desmontar ───────────────────────────────────────
+  // ── Timer cleanup on unmount ─────────────────────────────────────────────
   useEffect(() => {
     const timers = speechTimers.current
     return () => {

--- a/src/hooks/useSocket.test.ts
+++ b/src/hooks/useSocket.test.ts
@@ -29,29 +29,29 @@ describe('useSocket', () => {
     mockSocket.connected = false
   })
 
-  it('retorna status connecting quando socket não está conectado', () => {
+  it('returns connecting status when socket is not connected', () => {
     const { result } = renderHook(() => useSocket())
     expect(result.current.status).toBe('connecting')
   })
 
-  it('retorna status connected quando socket já está conectado', () => {
+  it('returns connected status when socket is already connected', () => {
     mockSocket.connected = true
     const { result } = renderHook(() => useSocket())
     expect(result.current.status).toBe('connected')
   })
 
-  it('chama connectSocket no mount', async () => {
+  it('calls connectSocket on mount', async () => {
     const { connectSocket } = await import('../services/socket')
     renderHook(() => useSocket())
     expect(connectSocket).toHaveBeenCalled()
   })
 
-  it('retorna o socket', () => {
+  it('returns the socket', () => {
     const { result } = renderHook(() => useSocket())
     expect(result.current.socket).toBeDefined()
   })
 
-  it('registra listeners no mount', () => {
+  it('registers listeners on mount', () => {
     renderHook(() => useSocket())
     expect(mockSocket.on).toHaveBeenCalledWith('connect', expect.any(Function))
     expect(mockSocket.on).toHaveBeenCalledWith('disconnect', expect.any(Function))
@@ -59,7 +59,7 @@ describe('useSocket', () => {
     expect(mockIo.on).toHaveBeenCalledWith('reconnect_attempt', expect.any(Function))
   })
 
-  it('remove listeners no unmount', () => {
+  it('removes listeners on unmount', () => {
     const { unmount } = renderHook(() => useSocket())
     unmount()
     expect(mockSocket.off).toHaveBeenCalledWith('connect', expect.any(Function))
@@ -68,14 +68,14 @@ describe('useSocket', () => {
     expect(mockIo.off).toHaveBeenCalledWith('reconnect_attempt', expect.any(Function))
   })
 
-  it('atualiza status para connected ao receber evento connect', () => {
+  it('updates status to connected when connect event is received', () => {
     const { result } = renderHook(() => useSocket())
     const onConnect = mockSocket.on.mock.calls.find(([e]) => e === 'connect')?.[1]
     act(() => onConnect?.())
     expect(result.current.status).toBe('connected')
   })
 
-  it('atualiza status para disconnected ao receber evento disconnect', () => {
+  it('updates status to disconnected when disconnect event is received', () => {
     mockSocket.connected = true
     const { result } = renderHook(() => useSocket())
     const onDisconnect = mockSocket.on.mock.calls.find(([e]) => e === 'disconnect')?.[1]
@@ -83,21 +83,21 @@ describe('useSocket', () => {
     expect(result.current.status).toBe('disconnected')
   })
 
-  it('atualiza status para error ao receber connect_error', () => {
+  it('updates status to error when connect_error is received', () => {
     const { result } = renderHook(() => useSocket())
     const onError = mockSocket.on.mock.calls.find(([e]) => e === 'connect_error')?.[1]
     act(() => onError?.())
     expect(result.current.status).toBe('error')
   })
 
-  it('atualiza status para reconnecting ao receber reconnect_attempt', () => {
+  it('updates status to reconnecting when reconnect_attempt is received', () => {
     const { result } = renderHook(() => useSocket())
     const onReconnect = mockIo.on.mock.calls.find(([e]) => e === 'reconnect_attempt')?.[1]
     act(() => onReconnect?.())
     expect(result.current.status).toBe('reconnecting')
   })
 
-  it('retorna objeto memoizado — mesma referência quando status não muda', () => {
+  it('returns memoized object — same reference when status does not change', () => {
     const { result, rerender } = renderHook(() => useSocket())
     const first = result.current
     rerender()

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,18 +1,23 @@
 import { useEffect, useMemo, useState } from 'react'
 import { connectSocket, socket } from '../services/socket'
 
-export type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'disconnected' | 'error'
+export type ConnectionStatus =
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected'
+  | 'error'
 
 export function useSocket() {
   const [status, setStatus] = useState<ConnectionStatus>(() =>
-    socket.connected ? 'connected' : 'connecting',
+    socket.connected ? 'connected' : 'connecting'
   )
 
   useEffect(() => {
-    // Inicia a conexão ao montar — autoConnect está desabilitado no singleton
+    // Start connection on mount — autoConnect is disabled on the singleton
     connectSocket()
 
-    // Resolve race condition: verifica estado atual após mount
+    // Resolve race condition: check current state after mount
     if (socket.connected) setStatus('connected')
 
     const onConnect = () => setStatus('connected')
@@ -33,6 +38,6 @@ export function useSocket() {
     }
   }, [])
 
-  // useMemo evita recriar o objeto a cada render (socket é singleton, só status muda)
+  // useMemo avoids recreating the object on every render (socket is singleton, only status changes)
   return useMemo(() => ({ socket, status }), [status])
 }

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -2,7 +2,7 @@ import { io, Socket } from 'socket.io-client'
 
 const BACKEND_URL = import.meta.env.VITE_MAGO_BACKEND_URL ?? 'http://localhost:3002'
 
-// --- Tipos dos eventos emitidos pelo MAGO backend ---
+// --- Types for events emitted by the MAGO backend ---
 
 export interface AgentStatus {
   agentId: string
@@ -36,7 +36,7 @@ export interface OfficeUser {
   y: number
 }
 
-// --- Mapa de eventos (ServerToClient) ---
+// --- Event map (ServerToClient) ---
 
 export interface ServerToClientEvents {
   'agent:status:updated': (data: AgentStatus) => void
@@ -56,8 +56,8 @@ export interface ClientToServerEvents {
 export type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>
 
 // --- Singleton ---
-// autoConnect: false — conexão iniciada explicitamente via connectSocket()
-// para permitir controle do ciclo de vida e facilitar testes
+// autoConnect: false — connection started explicitly via connectSocket()
+// to allow lifecycle control and facilitate testing
 
 export const socket: TypedSocket = io(BACKEND_URL, {
   reconnection: true,
@@ -73,7 +73,7 @@ export function connectSocket(): void {
   }
 }
 
-/** Retorna a instância singleton do socket — uso em hooks e testes. */
+/** Returns the singleton socket instance — used in hooks and tests. */
 export function getSocket(): TypedSocket {
   return socket
 }

--- a/src/test/colors.ts
+++ b/src/test/colors.ts
@@ -1,15 +1,15 @@
 /**
- * Normaliza cor CSS para o formato canônico `rgb(r, g, b)`.
+ * Normalizes a CSS color to the canonical `rgb(r, g, b)` format.
  *
- * Necessário porque happy-dom retorna estilos computados em hex (#rrggbb)
- * enquanto jsdom retornava rgb(). Garante asserções de cor agnósticas ao
- * ambiente de teste.
+ * Needed because happy-dom returns computed styles as hex (#rrggbb)
+ * while jsdom returned rgb(). Ensures color assertions are agnostic to
+ * the test environment.
  *
- * Formatos suportados:
+ * Supported formats:
  * - `#rgb`              → rgb(r, g, b)
  * - `#rrggbb`           → rgb(r, g, b)
- * - `rgb(r, g, b)`      → rgb(r, g, b)  (vírgulas com ou sem espaço)
- * - `rgb(r g b)`        → rgb(r, g, b)  (CSS moderno sem vírgulas)
+ * - `rgb(r, g, b)`      → rgb(r, g, b)  (commas with or without space)
+ * - `rgb(r g b)`        → rgb(r, g, b)  (modern CSS without commas)
  *
  * @example
  * toRgb('#00ff41')       // → 'rgb(0, 255, 65)'
@@ -31,7 +31,7 @@ export function toRgb(color: string): string {
     const b = parseInt(full.slice(4, 6), 16)
     return `rgb(${r}, ${g}, ${b})`
   }
-  // Cobre rgb(r,g,b) com vírgulas E rgb(r g b) moderno sem vírgulas
+  // Covers rgb(r,g,b) with commas AND modern rgb(r g b) without commas
   return color.replace(
     /rgb\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)\s*\)/,
     (_, r, g, b) => `rgb(${r}, ${g}, ${b})`

--- a/src/utils/avatar.test.ts
+++ b/src/utils/avatar.test.ts
@@ -2,52 +2,52 @@ import { describe, it, expect } from 'vitest'
 import { hashColor, initials, toPercent } from './avatar'
 
 describe('hashColor', () => {
-  it('retorna uma string de cor hex', () => {
+  it('returns a hex color string', () => {
     expect(hashColor('user-1')).toMatch(/^#[0-9a-f]{6}$/)
   })
 
-  it('retorna a mesma cor para o mesmo userId', () => {
+  it('returns the same color for the same userId', () => {
     expect(hashColor('abc')).toBe(hashColor('abc'))
   })
 
-  it('retorna cores distintas para userIds diferentes', () => {
-    const colors = new Set(['user-1','user-2','user-3','user-4'].map(hashColor))
+  it('returns distinct colors for different userIds', () => {
+    const colors = new Set(['user-1', 'user-2', 'user-3', 'user-4'].map(hashColor))
     expect(colors.size).toBeGreaterThan(1)
   })
 })
 
 describe('initials', () => {
-  it('retorna 2 letras maiúsculas de nome completo', () => {
+  it('returns 2 uppercase letters for a full name', () => {
     expect(initials('João Silva')).toBe('JS')
   })
 
-  it('retorna 2 primeiras letras para nome único', () => {
+  it('returns first 2 letters for a single name', () => {
     expect(initials('Alice')).toBe('AL')
   })
 
-  it('usa primeira e última palavra para nomes compostos', () => {
+  it('uses first and last word for compound names', () => {
     expect(initials('Maria da Silva')).toBe('MS')
   })
 
-  it('lida com espaços extras', () => {
+  it('handles extra spaces', () => {
     expect(initials('  Ana  Lima  ')).toBe('AL')
   })
 })
 
 describe('toPercent', () => {
-  it('converte px para porcentagem', () => {
+  it('converts px to percentage', () => {
     expect(toPercent(250, 1000)).toBe(25)
   })
 
-  it('clampeia no mínimo 0', () => {
+  it('clamps to minimum 0', () => {
     expect(toPercent(-50, 1000)).toBe(0)
   })
 
-  it('clampeia no máximo 100', () => {
+  it('clamps to maximum 100', () => {
     expect(toPercent(1200, 1000)).toBe(100)
   })
 
-  it('retorna 50 para o centro', () => {
+  it('returns 50 for the center', () => {
     expect(toPercent(500, 1000)).toBe(50)
   })
 })

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,6 +1,6 @@
 /**
- * Paleta de cores para avatares humanos.
- * Gerada via hash do userId — distribuição uniforme.
+ * Color palette for human avatars.
+ * Generated via userId hash — uniform distribution.
  */
 const AVATAR_PALETTE = [
   '#3b82f6', // blue
@@ -13,7 +13,7 @@ const AVATAR_PALETTE = [
   '#f43f5e', // rose
 ]
 
-/** Retorna uma cor estável para um dado userId. */
+/** Returns a stable color for a given userId. */
 export function hashColor(userId: string): string {
   let hash = 0
   for (let i = 0; i < userId.length; i++) {
@@ -22,7 +22,7 @@ export function hashColor(userId: string): string {
   return AVATAR_PALETTE[hash % AVATAR_PALETTE.length]
 }
 
-/** Retorna as iniciais (até 2 letras) de um nome. */
+/** Returns the initials (up to 2 letters) of a name. */
 export function initials(name: string): string {
   const parts = name.trim().split(/\s+/)
   if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
@@ -30,8 +30,8 @@ export function initials(name: string): string {
 }
 
 /**
- * Converte uma posição em pixels (relativa ao container) para percentual (0–100).
- * Clampeia para garantir que o avatar fique dentro dos limites.
+ * Converts a pixel position (relative to the container) to percentage (0–100).
+ * Clamps to ensure the avatar stays within bounds.
  */
 export function toPercent(px: number, total: number): number {
   return Math.min(100, Math.max(0, (px / total) * 100))


### PR DESCRIPTION
## Summary

- Translate all comments, JSDoc, UI strings, aria-labels, test descriptions and mock data to English
- Update `STATUS_LABEL` error value from `'erro'` → `'error'` with coordinated test updates across `OfficeCanvas.test` and `OfficeHUD.test`
- Switch `toLocaleTimeString` locale from `pt-BR` → `en-US` in `AgentDetailPanel`
- Update `sendFeedback` error prefix check from `startsWith('Erro')` → `startsWith('Failed')`
- Translate QUICK_MESSAGES, aria-labels, and all JSX/inline comments in all 9 components
- Update all 13 test files to match new English strings

Closes #61