### PR TITLE
refactor(styles): extract inline style objects to typed constants

### DIFF
--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -53,6 +53,26 @@ const STATUS_BADGE_COLOR: Record<string, string> = {
 
 const TOOLTIP_DELAY_MS = 400
 
+const STYLES = {
+  nameLabel: {
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 9,
+    letterSpacing: '0.05em',
+    textTransform: 'uppercase',
+    whiteSpace: 'nowrap',
+  } as React.CSSProperties,
+
+  badge: {
+    position: 'absolute',
+    bottom: -1,
+    right: -1,
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    border: '1.5px solid #0d1117',
+  } as React.CSSProperties,
+}
+
 export const AgentAvatar = memo(function AgentAvatar({
   agent,
   onClick,
@@ -160,30 +180,15 @@ export const AgentAvatar = memo(function AgentAvatar({
         <span
           aria-label={`status: ${agent.status}`}
           style={{
-            position: 'absolute',
-            bottom: -1,
-            right: -1,
-            width: 8,
-            height: 8,
-            borderRadius: '50%',
+            ...STYLES.badge,
             background: badgeColor,
-            border: '1.5px solid #0d1117',
             boxShadow: isOffline ? 'none' : `0 0 4px ${badgeColor}`,
           }}
         />
       </motion.div>
 
       {/* Agent name */}
-      <span
-        style={{
-          fontFamily: 'JetBrains Mono, monospace',
-          fontSize: 9,
-          color: isOffline ? '#374151' : '#6b7280',
-          letterSpacing: '0.05em',
-          textTransform: 'uppercase',
-          whiteSpace: 'nowrap',
-        }}
-      >
+      <span style={{ ...STYLES.nameLabel, color: isOffline ? '#374151' : '#6b7280' }}>
         {agent.name}
       </span>
     </motion.div>

--- a/src/components/AvatarTooltip.tsx
+++ b/src/components/AvatarTooltip.tsx
@@ -14,10 +14,43 @@ interface AvatarTooltipProps {
   placement?: 'top' | 'bottom'
 }
 
+const STYLES = {
+  tooltipBase: {
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    background: `${COLORS.bg}ee`,
+    border: `1px solid ${COLORS.zoneBorder}`,
+    borderRadius: 5,
+    padding: '6px 10px',
+    minWidth: 140,
+    zIndex: 1001,
+    pointerEvents: 'none',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 10,
+    whiteSpace: 'nowrap',
+    boxShadow: '0 4px 16px #00000088',
+  } as React.CSSProperties,
+
+  row: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 12,
+    lineHeight: 1.7,
+  } as React.CSSProperties,
+
+  rowLabel: {
+    color: COLORS.labelMuted,
+  } as React.CSSProperties,
+}
+
 export const AvatarTooltip = memo(function AvatarTooltip({
   lines,
   placement = 'top',
 }: AvatarTooltipProps) {
+  const placementStyle: React.CSSProperties =
+    placement === 'top' ? { bottom: 'calc(100% + 8px)' } : { top: 'calc(100% + 8px)' }
+
   return (
     <motion.div
       role="tooltip"
@@ -29,38 +62,19 @@ export const AvatarTooltip = memo(function AvatarTooltip({
         scale: 0.95,
         transition: { duration: 0.1 },
       }}
-      style={{
-        position: 'absolute',
-        ...(placement === 'top' ? { bottom: 'calc(100% + 8px)' } : { top: 'calc(100% + 8px)' }),
-        left: '50%',
-        transform: 'translateX(-50%)',
-        background: `${COLORS.bg}ee`,
-        border: `1px solid ${COLORS.zoneBorder}`,
-        borderRadius: 5,
-        padding: '6px 10px',
-        minWidth: 140,
-        zIndex: 1001,
-        pointerEvents: 'none',
-        fontFamily: 'JetBrains Mono, monospace',
-        fontSize: 10,
-        whiteSpace: 'nowrap',
-        boxShadow: '0 4px 16px #00000088',
-      }}
+      style={{ ...STYLES.tooltipBase, ...placementStyle }}
     >
       {lines.map((line, i) => (
         <div
           key={i}
           style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            gap: 12,
-            lineHeight: 1.7,
+            ...STYLES.row,
             borderTop: i > 0 && line.label === '' ? `1px solid ${COLORS.zoneBorder}` : undefined,
             paddingTop: i > 0 && line.label === '' ? 4 : undefined,
             marginTop: i > 0 && line.label === '' ? 2 : undefined,
           }}
         >
-          <span style={{ color: COLORS.labelMuted }}>{line.label}</span>
+          <span style={STYLES.rowLabel}>{line.label}</span>
           <span style={{ color: line.valueColor ?? COLORS.labelBright }}>{line.value}</span>
         </div>
       ))}

--- a/src/components/HumanAvatar.tsx
+++ b/src/components/HumanAvatar.tsx
@@ -14,6 +14,33 @@ interface HumanAvatarProps {
 
 const EMIT_DEBOUNCE_MS = 100
 
+const STYLES = {
+  nameStack: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 1,
+  } as React.CSSProperties,
+
+  youBadge: {
+    fontSize: 8,
+    fontFamily: 'JetBrains Mono, monospace',
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+  } as React.CSSProperties,
+
+  nameLabel: {
+    fontSize: 9,
+    fontFamily: 'JetBrains Mono, monospace',
+    color: '#6b7280',
+    letterSpacing: '0.04em',
+    whiteSpace: 'nowrap',
+    maxWidth: 64,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  } as React.CSSProperties,
+}
+
 export const HumanAvatar = memo(function HumanAvatar({ user, isMe, canvasRef }: HumanAvatarProps) {
   const color = hashColor(user.userId)
   const label = initials(user.name)
@@ -90,33 +117,9 @@ export const HumanAvatar = memo(function HumanAvatar({ user, isMe, canvasRef }: 
       </div>
 
       {/* YOU badge + name */}
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
-        {isMe && (
-          <span
-            style={{
-              fontSize: 8,
-              fontFamily: 'JetBrains Mono, monospace',
-              color,
-              letterSpacing: '0.08em',
-              textTransform: 'uppercase',
-            }}
-          >
-            you
-          </span>
-        )}
-        <span
-          style={{
-            fontSize: 9,
-            fontFamily: 'JetBrains Mono, monospace',
-            color: '#6b7280',
-            letterSpacing: '0.04em',
-            whiteSpace: 'nowrap',
-            maxWidth: 64,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-          title={user.name}
-        >
+      <div style={STYLES.nameStack}>
+        {isMe && <span style={{ ...STYLES.youBadge, color }}>you</span>}
+        <span style={STYLES.nameLabel} title={user.name}>
           {user.name}
         </span>
       </div>

--- a/src/components/OfficeCanvas.tsx
+++ b/src/components/OfficeCanvas.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode, type RefObject } from 'react'
+import { type ReactNode, type RefObject } from 'react'
 import { OFFICE_ZONES } from '../data/office-layout'
 import { OfficeRoom } from './OfficeRoom'
 import { OfficeHUD } from './OfficeHUD'
@@ -14,6 +14,26 @@ interface OfficeCanvasProps {
   canvasRef?: RefObject<HTMLDivElement | null>
 }
 
+const STYLES = {
+  canvas: {
+    position: 'relative',
+    width: '100%',
+    height: '100vh',
+    background: COLORS.bg,
+    overflow: 'hidden',
+    fontFamily: 'JetBrains Mono, monospace',
+  } as React.CSSProperties,
+
+  grid: {
+    position: 'absolute',
+    inset: 0,
+    backgroundImage: `radial-gradient(circle, ${COLORS.grid} 1px, transparent 1px)`,
+    backgroundSize: '28px 28px',
+    opacity: 0.4,
+    pointerEvents: 'none',
+  } as React.CSSProperties,
+}
+
 export function OfficeCanvas({
   children,
   connectionStatus,
@@ -21,32 +41,10 @@ export function OfficeCanvas({
   humanCount = 0,
   canvasRef,
 }: OfficeCanvasProps) {
-  const gridStyle = useMemo<React.CSSProperties>(
-    () => ({
-      position: 'absolute',
-      inset: 0,
-      backgroundImage: `radial-gradient(circle, ${COLORS.grid} 1px, transparent 1px)`,
-      backgroundSize: '28px 28px',
-      opacity: 0.4,
-      pointerEvents: 'none',
-    }),
-    []
-  )
-
   return (
-    <div
-      ref={canvasRef}
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100vh',
-        background: COLORS.bg,
-        overflow: 'hidden',
-        fontFamily: 'JetBrains Mono, monospace',
-      }}
-    >
+    <div ref={canvasRef} style={STYLES.canvas}>
       {/* Decorative grid */}
-      <div style={gridStyle} />
+      <div style={STYLES.grid} />
 
       {/* Office zones */}
       {OFFICE_ZONES.map((zone) => (

--- a/src/components/OfficeHUD.tsx
+++ b/src/components/OfficeHUD.tsx
@@ -9,6 +9,35 @@ interface OfficeHUDProps {
   humanCount?: number
 }
 
+const STYLES = {
+  container: {
+    position: 'absolute',
+    bottom: 16,
+    right: 16,
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    padding: '6px 12px',
+    background: COLORS.hudBg,
+    border: `1px solid ${COLORS.zoneBorder}`,
+    borderRadius: 6,
+    backdropFilter: 'blur(8px)',
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 11,
+    color: COLORS.label,
+  } as React.CSSProperties,
+
+  statusRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 5,
+  } as React.CSSProperties,
+
+  separator: {
+    color: COLORS.separator,
+  } as React.CSSProperties,
+}
+
 export const OfficeHUD = memo(function OfficeHUD({
   connectionStatus,
   agentCount = 0,
@@ -18,26 +47,9 @@ export const OfficeHUD = memo(function OfficeHUD({
   const label = STATUS_LABEL[connectionStatus]
 
   return (
-    <div
-      style={{
-        position: 'absolute',
-        bottom: 16,
-        right: 16,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        padding: '6px 12px',
-        background: COLORS.hudBg,
-        border: `1px solid ${COLORS.zoneBorder}`,
-        borderRadius: 6,
-        backdropFilter: 'blur(8px)',
-        fontFamily: 'JetBrains Mono, monospace',
-        fontSize: 11,
-        color: COLORS.label,
-      }}
-    >
+    <div style={STYLES.container}>
       {/* Connection status */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+      <div style={STYLES.statusRow}>
         <span
           aria-label={`status: ${label}`}
           role="status"
@@ -52,7 +64,7 @@ export const OfficeHUD = memo(function OfficeHUD({
         <span style={{ color }}>{label}</span>
       </div>
 
-      <span style={{ color: COLORS.separator }}>│</span>
+      <span style={STYLES.separator}>│</span>
 
       {/* Online agents */}
       <span>
@@ -61,7 +73,7 @@ export const OfficeHUD = memo(function OfficeHUD({
 
       {humanCount > 0 && (
         <>
-          <span style={{ color: COLORS.separator }}>│</span>
+          <span style={STYLES.separator}>│</span>
           <span>
             {humanCount} human{humanCount !== 1 ? 's' : ''}
           </span>

--- a/src/components/OfficeRoom.tsx
+++ b/src/components/OfficeRoom.tsx
@@ -6,6 +6,28 @@ interface OfficeRoomProps {
   zone: Zone
 }
 
+const STYLES = {
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '6px 10px',
+    borderBottom: `1px solid ${COLORS.zoneBorder}50`,
+  } as React.CSSProperties,
+
+  icon: {
+    fontSize: 12,
+  } as React.CSSProperties,
+
+  label: {
+    fontSize: 10,
+    fontFamily: 'JetBrains Mono, monospace',
+    color: COLORS.label,
+    letterSpacing: '0.05em',
+    textTransform: 'uppercase',
+  } as React.CSSProperties,
+}
+
 export const OfficeRoom = memo(function OfficeRoom({ zone }: OfficeRoomProps) {
   return (
     <div
@@ -23,27 +45,9 @@ export const OfficeRoom = memo(function OfficeRoom({ zone }: OfficeRoomProps) {
       }}
     >
       {/* Zone header */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-          padding: '6px 10px',
-          borderBottom: `1px solid ${COLORS.zoneBorder}50`,
-        }}
-      >
-        <span style={{ fontSize: 12 }}>{zone.icon}</span>
-        <span
-          style={{
-            fontSize: 10,
-            fontFamily: 'JetBrains Mono, monospace',
-            color: COLORS.label,
-            letterSpacing: '0.05em',
-            textTransform: 'uppercase',
-          }}
-        >
-          {zone.label}
-        </span>
+      <div style={STYLES.header}>
+        <span style={STYLES.icon}>{zone.icon}</span>
+        <span style={STYLES.label}>{zone.label}</span>
       </div>
     </div>
   )

--- a/src/components/OnlineUsersList.tsx
+++ b/src/components/OnlineUsersList.tsx
@@ -14,6 +14,46 @@ const ITEM_VARIANTS = {
   exit: { opacity: 0, x: -12, transition: { duration: 0.15 } },
 }
 
+const STYLES = {
+  container: {
+    position: 'fixed',
+    top: 16,
+    right: 16,
+    padding: '8px 10px',
+    background: '#0d1117cc',
+    border: '1px solid #1f2937',
+    borderRadius: 6,
+    backdropFilter: 'blur(8px)',
+    fontFamily: 'JetBrains Mono, monospace',
+    minWidth: 130,
+    maxWidth: 160,
+    zIndex: 50,
+  } as React.CSSProperties,
+
+  header: {
+    fontSize: 9,
+    color: '#4b5563',
+    letterSpacing: '0.1em',
+    textTransform: 'uppercase',
+    marginBottom: 6,
+    borderBottom: '1px solid #1f2937',
+    paddingBottom: 4,
+  } as React.CSSProperties,
+
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 7,
+    padding: '3px 0',
+  } as React.CSSProperties,
+
+  youBadge: {
+    opacity: 0.7,
+    marginLeft: 4,
+    fontSize: 8,
+  } as React.CSSProperties,
+}
+
 const UserRow = memo(function UserRow({ user, isMe }: { user: UserOfficeData; isMe: boolean }) {
   const color = user.userId ? hashColor(user.userId) : '#6b7280'
   const label = user.name ? initials(user.name) : '?'
@@ -25,12 +65,7 @@ const UserRow = memo(function UserRow({ user, isMe }: { user: UserOfficeData; is
       initial="hidden"
       animate="visible"
       exit="exit"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 7,
-        padding: '3px 0',
-      }}
+      style={STYLES.row}
     >
       {/* Mini circular avatar */}
       <div
@@ -67,7 +102,7 @@ const UserRow = memo(function UserRow({ user, isMe }: { user: UserOfficeData; is
         title={user.name}
       >
         {user.name}
-        {isMe && <span style={{ color, opacity: 0.7, marginLeft: 4, fontSize: 8 }}>you</span>}
+        {isMe && <span style={{ ...STYLES.youBadge, color }}>you</span>}
       </span>
     </motion.div>
   )
@@ -80,38 +115,9 @@ export const OnlineUsersList = memo(function OnlineUsersList({
   if (users.length === 0) return null
 
   return (
-    <div
-      role="list"
-      aria-label="online users"
-      style={{
-        position: 'fixed',
-        top: 16,
-        right: 16,
-        padding: '8px 10px',
-        background: '#0d1117cc',
-        border: '1px solid #1f2937',
-        borderRadius: 6,
-        backdropFilter: 'blur(8px)',
-        fontFamily: 'JetBrains Mono, monospace',
-        minWidth: 130,
-        maxWidth: 160,
-        zIndex: 50,
-      }}
-    >
+    <div role="list" aria-label="online users" style={STYLES.container}>
       {/* Header */}
-      <div
-        style={{
-          fontSize: 9,
-          color: '#4b5563',
-          letterSpacing: '0.1em',
-          textTransform: 'uppercase',
-          marginBottom: 6,
-          borderBottom: '1px solid #1f2937',
-          paddingBottom: 4,
-        }}
-      >
-        online · {users.length}
-      </div>
+      <div style={STYLES.header}>online · {users.length}</div>
 
       {/* List with AnimatePresence for join/leave animations */}
       <AnimatePresence initial={false}>

--- a/src/components/SpeechBubble.tsx
+++ b/src/components/SpeechBubble.tsx
@@ -8,6 +8,39 @@ interface SpeechBubbleProps {
 
 const MAX_LENGTH = 40
 
+const STYLES = {
+  bubble: {
+    position: 'absolute',
+    bottom: 'calc(100% + 8px)',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    maxWidth: 180,
+    padding: '5px 8px',
+    background: 'rgba(15, 23, 42, 0.92)',
+    borderRadius: 6,
+    fontFamily: 'JetBrains Mono, monospace',
+    fontSize: 10,
+    color: '#c9d1d9',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    lineHeight: 1.4,
+    pointerEvents: 'none',
+    zIndex: 10,
+    backdropFilter: 'blur(4px)',
+  } as React.CSSProperties,
+
+  arrow: {
+    position: 'absolute',
+    bottom: -5,
+    left: '50%',
+    transform: 'translateX(-50%)',
+    width: 0,
+    height: 0,
+    borderLeft: '5px solid transparent',
+    borderRight: '5px solid transparent',
+  } as React.CSSProperties,
+}
+
 const variants = {
   hidden: { scale: 0, opacity: 0, y: 8 },
   visible: {
@@ -31,42 +64,13 @@ export const SpeechBubble = memo(function SpeechBubble({ text, color }: SpeechBu
           initial="hidden"
           animate="visible"
           exit="exit"
-          style={{
-            position: 'absolute',
-            bottom: 'calc(100% + 8px)',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            maxWidth: 180,
-            padding: '5px 8px',
-            background: 'rgba(15, 23, 42, 0.92)',
-            border: `1px solid ${color}80`,
-            borderRadius: 6,
-            fontFamily: 'JetBrains Mono, monospace',
-            fontSize: 10,
-            color: '#c9d1d9',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            lineHeight: 1.4,
-            pointerEvents: 'none',
-            zIndex: 10,
-            backdropFilter: 'blur(4px)',
-          }}
+          style={{ ...STYLES.bubble, border: `1px solid ${color}80` }}
         >
           {truncated}
           {/* Downward-pointing arrow */}
           <span
             data-testid="speech-arrow"
-            style={{
-              position: 'absolute',
-              bottom: -5,
-              left: '50%',
-              transform: 'translateX(-50%)',
-              width: 0,
-              height: 0,
-              borderLeft: '5px solid transparent',
-              borderRight: '5px solid transparent',
-              borderTop: `5px solid ${color}80`,
-            }}
+            style={{ ...STYLES.arrow, borderTop: `5px solid ${color}80` }}
           />
         </motion.div>
       )}


### PR DESCRIPTION
## Summary

- Hoist static style objects to module-level `const STYLES` in 8 components, replacing repeated inline definitions
- Dynamic styles that depend on runtime values (`color`, `isOffline`, `isMe`) remain inline or spread from the base constant with overrides
- Removes `useMemo` from `OfficeCanvas` `gridStyle` — it was already effectively static (empty deps array)

**Affected components:** `OfficeCanvas`, `OfficeHUD`, `OfficeRoom`, `OnlineUsersList`, `HumanAvatar`, `AgentAvatar`, `AvatarTooltip`, `SpeechBubble`

All 136 tests pass, typecheck clean.

Closes #47