### PR TITLE
feat(avatar): arrastar agente para zona — override manual de zona

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence } from 'framer-motion'
 import { useSocket } from './hooks/useSocket'
 import { useOfficeState } from './hooks/useOfficeState'
 import type { AgentOfficeData } from './hooks/useOfficeState'
+import type { ZoneOverride } from './hooks/useOfficeState'
 import { OfficeCanvas } from './components/OfficeCanvas'
 import { AgentAvatar } from './components/AgentAvatar'
 import { HumanAvatar } from './components/HumanAvatar'
@@ -12,7 +13,7 @@ import { getSocket } from './services/socket'
 
 export function App() {
   const { status } = useSocket()
-  const { agents, users } = useOfficeState()
+  const { agents, users, setZoneOverride, clearZoneOverride } = useOfficeState()
   const canvasRef = useRef<HTMLDivElement>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
 
@@ -28,6 +29,20 @@ export function App() {
     setSelectedAgentId(null)
   }, [])
 
+  const handleZoneOverride = useCallback(
+    (agentId: string, override: ZoneOverride) => {
+      setZoneOverride(agentId, override)
+    },
+    [setZoneOverride]
+  )
+
+  const handleClearOverride = useCallback(
+    (agentId: string) => {
+      clearZoneOverride(agentId)
+    },
+    [clearZoneOverride]
+  )
+
   return (
     <>
       <OfficeCanvas
@@ -42,6 +57,9 @@ export function App() {
             agent={agent}
             onClick={handleAgentClick}
             isSelected={agent.id === selectedAgentId}
+            canvasRef={canvasRef}
+            onZoneOverride={handleZoneOverride}
+            onClearOverride={handleClearOverride}
           />
         ))}
         {users.map((user) => (

--- a/src/components/AgentAvatar.test.tsx
+++ b/src/components/AgentAvatar.test.tsx
@@ -9,6 +9,7 @@ vi.mock('framer-motion', async () => {
   const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
   return {
     ...actual,
+    useMotionValue: () => ({ set: vi.fn(), get: vi.fn() }),
     motion: {
       div: ({
         children,
@@ -20,6 +21,13 @@ vi.mock('framer-motion', async () => {
         initial: _i,
         exit: _e,
         layout: _l,
+        drag: _drag,
+        dragConstraints: _dc,
+        dragElastic: _de,
+        dragMomentum: _dm,
+        onDragEnd: _ode,
+        x: _x,
+        y: _y,
         ...rest
       }: MotionDivProps) => <div {...rest}>{children}</div>,
     },
@@ -38,6 +46,7 @@ const mockAgent: AgentOfficeData = {
   position: { x: 30, y: 50 },
   color: '#8b5cf6',
   speechText: null,
+  isManualOverride: false,
 }
 
 describe('AgentAvatar', () => {
@@ -93,6 +102,40 @@ describe('AgentAvatar', () => {
   it('has aria-label with agent name and status', () => {
     render(<AgentAvatar agent={mockAgent} />)
     expect(document.querySelector('[aria-label*="Architect"]')).toBeTruthy()
+  })
+
+  describe('manual override', () => {
+    it('shows anchor badge when isManualOverride is true', () => {
+      render(<AgentAvatar agent={{ ...mockAgent, isManualOverride: true }} />)
+      expect(document.querySelector('[aria-label="manual override"]')).toBeTruthy()
+    })
+
+    it('hides anchor badge when isManualOverride is false', () => {
+      render(<AgentAvatar agent={mockAgent} />)
+      expect(document.querySelector('[aria-label="manual override"]')).toBeNull()
+    })
+
+    it('shows reset button when isManualOverride is true', () => {
+      const onClear = vi.fn()
+      render(
+        <AgentAvatar agent={{ ...mockAgent, isManualOverride: true }} onClearOverride={onClear} />
+      )
+      expect(screen.getByRole('button', { name: /reset position/i })).toBeTruthy()
+    })
+
+    it('hides reset button when isManualOverride is false', () => {
+      render(<AgentAvatar agent={mockAgent} />)
+      expect(screen.queryByRole('button', { name: /reset position/i })).toBeNull()
+    })
+
+    it('calls onClearOverride when reset button is clicked', () => {
+      const onClear = vi.fn()
+      render(
+        <AgentAvatar agent={{ ...mockAgent, isManualOverride: true }} onClearOverride={onClear} />
+      )
+      fireEvent.click(screen.getByRole('button', { name: /reset position/i }))
+      expect(onClear).toHaveBeenCalledWith('rx-architect')
+    })
   })
 
   describe('tooltip with fake timers', () => {

--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -1,15 +1,23 @@
-import { memo, useState, useRef, useCallback, useEffect, useMemo } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
-import type { TargetAndTransition } from 'framer-motion'
+import { memo, useState, useRef, useCallback, useEffect, useMemo, type RefObject } from 'react'
+import { motion, AnimatePresence, useMotionValue } from 'framer-motion'
+import type { TargetAndTransition, PanInfo } from 'framer-motion'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
+import type { ZoneOverride } from '../hooks/useOfficeState'
 import { SpeechBubble } from './SpeechBubble'
 import { AvatarTooltip } from './AvatarTooltip'
 import { AGENT_STATUS_LABEL } from '../constants/agent'
+import { OFFICE_ZONES } from '../data/office-layout'
 
 interface AgentAvatarProps {
   agent: AgentOfficeData
   onClick?: (agent: AgentOfficeData) => void
   isSelected?: boolean
+  /** Canvas ref — enables drag when provided */
+  canvasRef?: RefObject<HTMLDivElement | null>
+  /** Called when agent is dropped into a valid zone */
+  onZoneOverride?: (agentId: string, override: ZoneOverride) => void
+  /** Called when the manual override is reset */
+  onClearOverride?: (agentId: string) => void
 }
 
 /** Icon per agent role */
@@ -42,6 +50,12 @@ const STATUS_ANIMATION: Record<string, TargetAndTransition> = {
   offline: {},
 }
 
+/** Shake animation played when agent is dropped outside a valid zone */
+const SHAKE_ANIMATION: TargetAndTransition = {
+  x: [-6, 6, -6, 6, -3, 3, 0],
+  transition: { duration: 0.4 },
+}
+
 /** Status badge color */
 const STATUS_BADGE_COLOR: Record<string, string> = {
   idle: '#6b7280',
@@ -71,19 +85,49 @@ const STYLES = {
     borderRadius: '50%',
     border: '1.5px solid #0d1117',
   } as React.CSSProperties,
+
+  anchorBadge: {
+    position: 'absolute',
+    top: -4,
+    left: -4,
+    fontSize: 8,
+    lineHeight: 1,
+    userSelect: 'none',
+  } as React.CSSProperties,
+
+  resetBtn: {
+    background: 'none',
+    border: '1px solid #374151',
+    borderRadius: 3,
+    color: '#6b7280',
+    fontSize: 8,
+    padding: '1px 5px',
+    cursor: 'pointer',
+    fontFamily: 'JetBrains Mono, monospace',
+    whiteSpace: 'nowrap',
+  } as React.CSSProperties,
 }
 
 export const AgentAvatar = memo(function AgentAvatar({
   agent,
   onClick,
   isSelected = false,
+  canvasRef,
+  onZoneOverride,
+  onClearOverride,
 }: AgentAvatarProps) {
   const icon = ROLE_ICON[agent.role] ?? DEFAULT_ICON
-  const animation = STATUS_ANIMATION[agent.status] ?? {}
   const badgeColor = STATUS_BADGE_COLOR[agent.status] ?? '#6b7280'
   const isOffline = agent.status === 'offline'
+  const isDraggable = !!canvasRef
+
   const [showTooltip, setShowTooltip] = useState(false)
+  const [shaking, setShaking] = useState(false)
   const tooltipTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Drag offset motion values — reset to 0 after each drag
+  const dragX = useMotionValue(0)
+  const dragY = useMotionValue(0)
 
   const handleMouseEnter = useCallback(() => {
     tooltipTimer.current = setTimeout(() => setShowTooltip(true), TOOLTIP_DELAY_MS)
@@ -94,12 +138,52 @@ export const AgentAvatar = memo(function AgentAvatar({
     setShowTooltip(false)
   }, [])
 
-  // Cleanup timer on unmount to avoid memory leak
+  // Cleanup timer on unmount
   useEffect(() => {
     return () => {
       if (tooltipTimer.current) clearTimeout(tooltipTimer.current)
     }
   }, [])
+
+  const handleDragEnd = useCallback(
+    (_e: unknown, info: PanInfo) => {
+      // Reset drag transform offsets regardless of where we dropped
+      dragX.set(0)
+      dragY.set(0)
+
+      if (!canvasRef?.current) return
+
+      const rect = canvasRef.current.getBoundingClientRect()
+      const xPct = ((info.point.x - rect.left) / rect.width) * 100
+      const yPct = ((info.point.y - rect.top) / rect.height) * 100
+
+      // Find the zone containing the drop point
+      const zone = OFFICE_ZONES.find(
+        (z) => xPct >= z.x && xPct <= z.x + z.width && yPct >= z.y && yPct <= z.y + z.height
+      )
+
+      if (zone) {
+        onZoneOverride?.(agent.id, { x: xPct, y: yPct, zoneId: zone.id })
+      } else {
+        // Dropped outside any zone — shake and snap back
+        setShaking(true)
+        setTimeout(() => setShaking(false), 500)
+      }
+    },
+    [canvasRef, agent.id, onZoneOverride, dragX, dragY]
+  )
+
+  const handleReset = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onClearOverride?.(agent.id)
+    },
+    [agent.id, onClearOverride]
+  )
+
+  // Choose the animation: shake overrides status animation
+  const outerAnimation = shaking ? SHAKE_ANIMATION : undefined
+  const innerAnimation = shaking ? undefined : (STATUS_ANIMATION[agent.status] ?? {})
 
   const tooltipLines = useMemo(
     () => [
@@ -118,14 +202,19 @@ export const AgentAvatar = memo(function AgentAvatar({
           ]
         : []),
       ...(agent.zoneId ? [{ label: 'zone', value: agent.zoneId }] : []),
+      ...(agent.isManualOverride ? [{ label: 'mode', value: '⚓ manual' }] : []),
     ],
-    [agent.role, agent.status, agent.currentTask, agent.zoneId, badgeColor]
+    [agent.role, agent.status, agent.currentTask, agent.zoneId, agent.isManualOverride, badgeColor]
   )
 
   return (
     <motion.div
       layoutId={`agent-${agent.id}`}
       aria-label={`agent ${agent.name}, status ${AGENT_STATUS_LABEL[agent.status] ?? agent.status}`}
+      drag={isDraggable}
+      dragConstraints={canvasRef ?? undefined}
+      dragElastic={0}
+      dragMomentum={false}
       style={{
         position: 'absolute',
         left: `${agent.position.x}%`,
@@ -135,13 +224,18 @@ export const AgentAvatar = memo(function AgentAvatar({
         flexDirection: 'column',
         alignItems: 'center',
         gap: 4,
-        cursor: onClick ? 'pointer' : 'default',
+        cursor: isDraggable ? 'grab' : onClick ? 'pointer' : 'default',
         userSelect: 'none',
+        x: dragX,
+        y: dragY,
+        zIndex: isDraggable ? 10 : undefined,
       }}
+      animate={outerAnimation}
       onClick={() => onClick?.(agent)}
       whileHover={onClick ? { scale: 1.1 } : undefined}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      onDragEnd={isDraggable ? handleDragEnd : undefined}
     >
       {/* Tooltip */}
       <AnimatePresence>
@@ -153,7 +247,7 @@ export const AgentAvatar = memo(function AgentAvatar({
 
       {/* Circular avatar */}
       <motion.div
-        animate={animation}
+        animate={innerAnimation}
         style={{
           position: 'relative',
           width: 36,
@@ -185,12 +279,30 @@ export const AgentAvatar = memo(function AgentAvatar({
             boxShadow: isOffline ? 'none' : `0 0 4px ${badgeColor}`,
           }}
         />
+
+        {/* Anchor badge — shown when position is manually overridden */}
+        {agent.isManualOverride && (
+          <span aria-label="manual override" style={STYLES.anchorBadge}>
+            ⚓
+          </span>
+        )}
       </motion.div>
 
       {/* Agent name */}
       <span style={{ ...STYLES.nameLabel, color: isOffline ? '#374151' : '#6b7280' }}>
         {agent.name}
       </span>
+
+      {/* Reset button — shown only when override is active */}
+      {agent.isManualOverride && (
+        <button
+          aria-label={`reset position for ${agent.name}`}
+          onClick={handleReset}
+          style={STYLES.resetBtn}
+        >
+          reset ↺
+        </button>
+      )}
     </motion.div>
   )
 })

--- a/src/components/AgentDetailPanel.test.tsx
+++ b/src/components/AgentDetailPanel.test.tsx
@@ -54,6 +54,7 @@ const mockAgent: AgentOfficeData = {
   position: { x: 50, y: 50 },
   color: '#8b5cf6',
   speechText: null,
+  isManualOverride: false,
 }
 
 describe('AgentDetailPanel', () => {

--- a/src/hooks/useOfficeState.test.ts
+++ b/src/hooks/useOfficeState.test.ts
@@ -281,6 +281,70 @@ describe('useOfficeState — socket events', () => {
   })
 })
 
+describe('useOfficeState — zone override', () => {
+  it('setZoneOverride applies a manual position override', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      result.current.setZoneOverride('rx-architect', { x: 70, y: 20, zoneId: 'review-room' })
+    })
+
+    const agent = result.current.agents.find((a) => a.id === 'rx-architect')
+    expect(agent?.isManualOverride).toBe(true)
+    expect(agent?.position.x).toBe(70)
+    expect(agent?.position.y).toBe(20)
+    expect(agent?.zoneId).toBe('review-room')
+  })
+
+  it('clearZoneOverride restores auto-computed position', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      result.current.setZoneOverride('rx-architect', { x: 70, y: 20, zoneId: 'review-room' })
+    })
+    act(() => {
+      result.current.clearZoneOverride('rx-architect')
+    })
+
+    const agent = result.current.agents.find((a) => a.id === 'rx-architect')
+    expect(agent?.isManualOverride).toBe(false)
+    // Position reverts to auto-computed value for idle agent in coffee-corner
+    expect(agent?.zoneId).toBe('coffee-corner')
+  })
+
+  it('agent:status:updated clears override for that agent', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      result.current.setZoneOverride('rx-architect', { x: 70, y: 20, zoneId: 'review-room' })
+    })
+    expect(result.current.agents.find((a) => a.id === 'rx-architect')?.isManualOverride).toBe(true)
+
+    act(() => {
+      const handler = socketListeners.get('agent:status:updated')
+      handler?.({ agentId: 'rx-architect', status: 'idle', lastAction: '' })
+    })
+
+    const agent = result.current.agents.find((a) => a.id === 'rx-architect')
+    expect(agent?.isManualOverride).toBe(false)
+  })
+
+  it('override for one agent does not affect other agents', async () => {
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      result.current.setZoneOverride('rx-architect', { x: 70, y: 20, zoneId: 'review-room' })
+    })
+
+    const backend = result.current.agents.find((a) => a.id === 'rx-backend')
+    expect(backend?.isManualOverride).toBe(false)
+  })
+})
+
 describe('useOfficeState — cleanup', () => {
   it('removes socket listeners on unmount', async () => {
     const { result, unmount } = renderHook(() => useOfficeState())

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -35,6 +35,8 @@ export interface AgentOfficeData {
   color: string
   /** Current SpeechBubble text (null = hidden) */
   speechText: string | null
+  /** True when position was manually overridden by drag (visual only) */
+  isManualOverride: boolean
 }
 
 export interface UserOfficeData {
@@ -45,11 +47,22 @@ export interface UserOfficeData {
   y: number
 }
 
+/** A manual zone override for a single agent */
+export interface ZoneOverride {
+  /** Canvas-relative X position in % */
+  x: number
+  /** Canvas-relative Y position in % */
+  y: number
+  zoneId: string
+}
+
 export interface OfficeState {
   agents: AgentOfficeData[]
   users: UserOfficeData[]
   isLoading: boolean
   error: string | null
+  /** Manual position overrides by agentId — cleared on next agent:status:updated */
+  overrides: Record<string, ZoneOverride>
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -78,6 +91,7 @@ function enrichAgent(raw: RawAgent): AgentOfficeData {
     position,
     color: getAgentColor(raw.id),
     speechText: null,
+    isManualOverride: false,
   }
 }
 
@@ -88,6 +102,8 @@ type Action =
   | { type: 'AGENT_STATUS_UPDATED'; agentId: string; status: string; lastAction: string }
   | { type: 'AGENT_SPEECH'; agentId: string; text: string }
   | { type: 'AGENT_SPEECH_CLEAR'; agentId: string }
+  | { type: 'AGENT_ZONE_OVERRIDE'; agentId: string; override: ZoneOverride }
+  | { type: 'AGENT_ZONE_CLEAR_OVERRIDE'; agentId: string }
   | { type: 'USER_JOINED'; user: OfficeUser }
   | { type: 'USER_LEFT'; socketId: string }
   | { type: 'USER_MOVED'; socketId: string; x: number; y: number }
@@ -103,9 +119,14 @@ function reducer(state: OfficeState, action: Action): OfficeState {
         agents: action.agents.map(enrichAgent),
       }
 
-    case 'AGENT_STATUS_UPDATED':
+    case 'AGENT_STATUS_UPDATED': {
+      // Clear any manual override for this agent — backend has the real zone now
+      const overrides = { ...state.overrides }
+      delete overrides[action.agentId]
+
       return {
         ...state,
+        overrides,
         agents: state.agents.map((a) => {
           if (a.id !== action.agentId) return a
           const raw: RawAgent = {
@@ -121,6 +142,7 @@ function reducer(state: OfficeState, action: Action): OfficeState {
           return { ...enrichAgent(raw), speechText: a.speechText }
         }),
       }
+    }
 
     case 'AGENT_SPEECH':
       return {
@@ -135,6 +157,18 @@ function reducer(state: OfficeState, action: Action): OfficeState {
         ...state,
         agents: state.agents.map((a) => (a.id === action.agentId ? { ...a, speechText: null } : a)),
       }
+
+    case 'AGENT_ZONE_OVERRIDE':
+      return {
+        ...state,
+        overrides: { ...state.overrides, [action.agentId]: action.override },
+      }
+
+    case 'AGENT_ZONE_CLEAR_OVERRIDE': {
+      const overrides = { ...state.overrides }
+      delete overrides[action.agentId]
+      return { ...state, overrides }
+    }
 
     case 'USER_JOINED':
       return {
@@ -169,6 +203,7 @@ const INITIAL_STATE: OfficeState = {
   users: [],
   isLoading: true,
   error: null,
+  overrides: {},
 }
 
 // ─── Hook ───────────────────────────────────────────────────────────────────
@@ -176,7 +211,14 @@ const INITIAL_STATE: OfficeState = {
 const BACKEND_URL = import.meta.env.VITE_MAGO_BACKEND_URL ?? 'http://localhost:3002'
 const AGENTS_URL = `${BACKEND_URL}/api/dashboard/agents`
 
-export function useOfficeState(): OfficeState {
+export interface UseOfficeStateReturn extends Omit<OfficeState, 'overrides'> {
+  /** Apply a manual position override for an agent (drag-and-drop) */
+  setZoneOverride: (agentId: string, override: ZoneOverride) => void
+  /** Remove a manual override, restoring the auto-computed position */
+  clearZoneOverride: (agentId: string) => void
+}
+
+export function useOfficeState(): UseOfficeStateReturn {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
 
   // Keep refs of speech bubble timers per agent for cleanup
@@ -190,6 +232,14 @@ export function useOfficeState(): OfficeState {
       speechTimers.current.delete(agentId)
     }, 5000)
     speechTimers.current.set(agentId, timer)
+  }, [])
+
+  const setZoneOverride = useCallback((agentId: string, override: ZoneOverride) => {
+    dispatch({ type: 'AGENT_ZONE_OVERRIDE', agentId, override })
+  }, [])
+
+  const clearZoneOverride = useCallback((agentId: string) => {
+    dispatch({ type: 'AGENT_ZONE_CLEAR_OVERRIDE', agentId })
   }, [])
 
   // ── Initial load via REST ────────────────────────────────────────────────
@@ -274,5 +324,24 @@ export function useOfficeState(): OfficeState {
     }
   }, [])
 
-  return state
+  // Apply overrides to agent positions before returning
+  const agents = state.agents.map((a) => {
+    const ov = state.overrides[a.id]
+    if (!ov) return a
+    return {
+      ...a,
+      position: { x: ov.x, y: ov.y },
+      zoneId: ov.zoneId,
+      isManualOverride: true,
+    }
+  })
+
+  return {
+    agents,
+    users: state.users,
+    isLoading: state.isLoading,
+    error: state.error,
+    setZoneOverride,
+    clearZoneOverride,
+  }
 }


### PR DESCRIPTION
## Summary

- `AgentAvatar` recebe `canvasRef`, `onZoneOverride` e `onClearOverride`
- Drag com Framer Motion: `drag`, `dragConstraints={canvasRef}`, `dragElastic=0`, `dragMomentum=false`
- Drop em zona válida → posição manual + badge ⚓ + botão `reset ↺`
- Drop fora de zona → animação shake e snap de volta
- `useOfficeState`: novas ações `AGENT_ZONE_OVERRIDE` / `AGENT_ZONE_CLEAR_OVERRIDE`; override limpo no próximo `agent:status:updated`
- `AgentOfficeData.isManualOverride: boolean` adicionado ao tipo
- 9 novos testes (5 em `AgentAvatar.test.tsx`, 4 em `useOfficeState.test.ts`)
- 145 testes passando, typecheck limpo

closes #20