### PR TITLE
fix(deploy): atualizar node para v22 no deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,7 +16,7 @@ git pull origin main --ff-only
 echo "--- Node.js via NVM ---"
 # shellcheck source=/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm use 20
+nvm use 22
 
 echo "--- Instalar dependências ---"
 COREPACK_ENABLE_STRICT=0 pnpm install --frozen-lockfile


### PR DESCRIPTION
deploy.sh usava `nvm use 20` enquanto `.nvmrc` e `package.json` engines definem `node >=22`.

closes #67