### PR TITLE
ci: adicionar job e2e com playwright ao pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,43 @@ jobs:
         if: always()
         with:
           fail_ci_if_error: false
+
+  e2e:
+    name: E2E · Playwright
+    runs-on: ubuntu-latest
+    needs: ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build
+        run: pnpm build
+
+      - name: E2E tests
+        run: pnpm exec playwright test
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7


### PR DESCRIPTION
Adiciona job `e2e` separado ao `ci.yml` que roda após o job `ci` (`needs: ci`):

- Instala Chromium via `playwright install --with-deps`
- Build do app antes dos testes (necessário para `pnpm preview`)
- Upload do `playwright-report/` como artifact (retenção 7 dias)

closes #68