### PR TITLE
feat(ui): loading/error state visível na office view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { useOfficeState } from './hooks/useOfficeState'
 import type { AgentOfficeData } from './hooks/useOfficeState'
 import type { ZoneOverride } from './hooks/useOfficeState'
 import { OfficeCanvas } from './components/OfficeCanvas'
+import { OfficeOverlay } from './components/OfficeOverlay'
 import { AgentAvatar } from './components/AgentAvatar'
 import { HumanAvatar } from './components/HumanAvatar'
 import { OnlineUsersList } from './components/OnlineUsersList'
@@ -13,7 +14,8 @@ import { getSocket } from './services/socket'
 
 export function App() {
   const { status } = useSocket()
-  const { agents, users, setZoneOverride, clearZoneOverride } = useOfficeState()
+  const { agents, users, isLoading, error, setZoneOverride, clearZoneOverride, retry } =
+    useOfficeState()
   const canvasRef = useRef<HTMLDivElement>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
 
@@ -70,6 +72,9 @@ export function App() {
             canvasRef={canvasRef}
           />
         ))}
+
+        {/* Loading / error overlay — sits inside the canvas */}
+        <OfficeOverlay isLoading={isLoading} error={error} onRetry={retry} />
       </OfficeCanvas>
 
       <OnlineUsersList users={users} mySocketId={mySocketId} />

--- a/src/components/OfficeOverlay.test.tsx
+++ b/src/components/OfficeOverlay.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { OfficeOverlay } from './OfficeOverlay'
+
+describe('OfficeOverlay — returns null when idle', () => {
+  it('renders nothing when isLoading=false and error=null', () => {
+    const { container } = render(<OfficeOverlay isLoading={false} error={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when no props are given', () => {
+    const { container } = render(<OfficeOverlay />)
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('OfficeOverlay — loading state', () => {
+  it('renders status element with aria-label when isLoading=true', () => {
+    render(<OfficeOverlay isLoading={true} />)
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(screen.getByLabelText('loading office')).toBeTruthy()
+  })
+
+  it('shows connecting message', () => {
+    render(<OfficeOverlay isLoading={true} />)
+    expect(screen.getByText(/connecting to MAGO/i)).toBeTruthy()
+  })
+
+  it('loading takes priority over error when both are set', () => {
+    render(<OfficeOverlay isLoading={true} error="some error" />)
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('OfficeOverlay — error state', () => {
+  it('renders alert element with aria-label when error is set', () => {
+    render(<OfficeOverlay error="HTTP 500" />)
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByLabelText('office error')).toBeTruthy()
+  })
+
+  it('shows failed to load agents message', () => {
+    render(<OfficeOverlay error="HTTP 500" />)
+    expect(screen.getByText(/failed to load agents/i)).toBeTruthy()
+  })
+
+  it('shows the error detail text', () => {
+    render(<OfficeOverlay error="HTTP 500" />)
+    expect(screen.getByText('HTTP 500')).toBeTruthy()
+  })
+
+  it('renders retry button when onRetry is provided', () => {
+    render(<OfficeOverlay error="timeout" onRetry={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /retry loading/i })).toBeTruthy()
+  })
+
+  it('does not render retry button when onRetry is omitted', () => {
+    render(<OfficeOverlay error="timeout" />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('calls onRetry when retry button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<OfficeOverlay error="timeout" onRetry={onRetry} />)
+    fireEvent.click(screen.getByRole('button', { name: /retry loading/i }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/OfficeOverlay.tsx
+++ b/src/components/OfficeOverlay.tsx
@@ -1,0 +1,82 @@
+import { memo, useCallback } from 'react'
+import { COLORS } from '../constants/theme'
+
+interface OfficeOverlayProps {
+  /** Show loading spinner */
+  isLoading?: boolean
+  /** Error message — shows error state when set */
+  error?: string | null
+  /** Called when user clicks the retry button */
+  onRetry?: () => void
+}
+
+const STYLES = {
+  overlay: {
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    zIndex: 50,
+    fontFamily: 'JetBrains Mono, monospace',
+    pointerEvents: 'none',
+  } as React.CSSProperties,
+
+  text: {
+    fontSize: 12,
+    letterSpacing: '0.08em',
+  } as React.CSSProperties,
+
+  retryBtn: {
+    marginTop: 4,
+    background: 'none',
+    border: `1px solid ${COLORS.zoneBorder}`,
+    borderRadius: 4,
+    color: COLORS.label,
+    fontSize: 11,
+    padding: '4px 14px',
+    cursor: 'pointer',
+    fontFamily: 'JetBrains Mono, monospace',
+    letterSpacing: '0.06em',
+    pointerEvents: 'auto',
+    transition: 'border-color 0.15s, color 0.15s',
+  } as React.CSSProperties,
+}
+
+export const OfficeOverlay = memo(function OfficeOverlay({
+  isLoading = false,
+  error = null,
+  onRetry,
+}: OfficeOverlayProps) {
+  const handleRetry = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onRetry?.()
+    },
+    [onRetry]
+  )
+
+  if (!isLoading && !error) return null
+
+  if (isLoading) {
+    return (
+      <div role="status" aria-label="loading office" style={STYLES.overlay}>
+        <span style={{ ...STYLES.text, color: COLORS.label }}>⟳ connecting to MAGO...</span>
+      </div>
+    )
+  }
+
+  return (
+    <div role="alert" aria-label="office error" style={STYLES.overlay}>
+      <span style={{ ...STYLES.text, color: '#ef4444' }}>⚠ failed to load agents</span>
+      <span style={{ ...STYLES.text, fontSize: 10, color: COLORS.labelMuted }}>{error}</span>
+      {onRetry && (
+        <button aria-label="retry loading" onClick={handleRetry} style={STYLES.retryBtn}>
+          retry
+        </button>
+      )}
+    </div>
+  )
+})

--- a/src/hooks/useOfficeState.test.ts
+++ b/src/hooks/useOfficeState.test.ts
@@ -345,6 +345,60 @@ describe('useOfficeState — zone override', () => {
   })
 })
 
+describe('useOfficeState — retry', () => {
+  it('retry re-triggers the fetch and clears the error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.error).toMatch(/503/))
+
+    // Switch mock to succeed on second call
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockAgents),
+      })
+    )
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeNull()
+    expect(result.current.agents).toHaveLength(3)
+  })
+
+  it('retry sets isLoading=true before fetch resolves', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+
+    const { result } = renderHook(() => useOfficeState())
+    await waitFor(() => expect(result.current.error).toMatch(/503/))
+
+    // Use a pending promise to freeze the fetch mid-flight
+    let resolveFetch!: (v: unknown) => void
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(
+        new Promise((res) => {
+          resolveFetch = res
+        })
+      )
+    )
+
+    act(() => {
+      result.current.retry()
+    })
+
+    expect(result.current.isLoading).toBe(true)
+
+    // Resolve to avoid lingering promise
+    resolveFetch({ ok: true, json: () => Promise.resolve(mockAgents) })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+})
+
 describe('useOfficeState — cleanup', () => {
   it('removes socket listeners on unmount', async () => {
     const { result, unmount } = renderHook(() => useOfficeState())

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useCallback, useRef } from 'react'
+import { useEffect, useReducer, useCallback, useRef, useState } from 'react'
 import { getSocket } from '../services/socket'
 import type {
   AgentStatus as SocketAgentStatus,
@@ -98,6 +98,7 @@ function enrichAgent(raw: RawAgent): AgentOfficeData {
 // ─── Reducer ────────────────────────────────────────────────────────────────
 
 type Action =
+  | { type: 'FETCH_START' }
   | { type: 'AGENTS_LOADED'; agents: RawAgent[] }
   | { type: 'AGENT_STATUS_UPDATED'; agentId: string; status: string; lastAction: string }
   | { type: 'AGENT_SPEECH'; agentId: string; text: string }
@@ -111,6 +112,9 @@ type Action =
 
 function reducer(state: OfficeState, action: Action): OfficeState {
   switch (action.type) {
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null }
+
     case 'AGENTS_LOADED':
       return {
         ...state,
@@ -216,10 +220,13 @@ export interface UseOfficeStateReturn extends Omit<OfficeState, 'overrides'> {
   setZoneOverride: (agentId: string, override: ZoneOverride) => void
   /** Remove a manual override, restoring the auto-computed position */
   clearZoneOverride: (agentId: string) => void
+  /** Re-trigger the agents REST fetch (clears error and sets isLoading) */
+  retry: () => void
 }
 
 export function useOfficeState(): UseOfficeStateReturn {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+  const [retryCount, setRetryCount] = useState(0)
 
   // Keep refs of speech bubble timers per agent for cleanup
   const speechTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
@@ -242,9 +249,15 @@ export function useOfficeState(): UseOfficeStateReturn {
     dispatch({ type: 'AGENT_ZONE_CLEAR_OVERRIDE', agentId })
   }, [])
 
+  const retry = useCallback(() => {
+    setRetryCount((c) => c + 1)
+  }, [])
+
   // ── Initial load via REST ────────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false
+
+    dispatch({ type: 'FETCH_START' })
 
     fetch(AGENTS_URL)
       .then((res) => {
@@ -264,7 +277,7 @@ export function useOfficeState(): UseOfficeStateReturn {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [retryCount])
 
   // ── Socket events ───────────────────────────────────────────────────────
   useEffect(() => {
@@ -343,5 +356,6 @@ export function useOfficeState(): UseOfficeStateReturn {
     error: state.error,
     setZoneOverride,
     clearZoneOverride,
+    retry,
   }
 }


### PR DESCRIPTION
## O que foi feito

Adiciona `OfficeOverlay` — componente que renderiza sobre o canvas enquanto os agentes carregam ou quando ocorre erro de rede.

### Mudanças

- **`src/components/OfficeOverlay.tsx`** — novo componente com:
  - Loading: `role="status"` + mensagem "⟳ connecting to MAGO..."
  - Error: `role="alert"` + "⚠ failed to load agents" + detalhe do erro + botão retry
  - Retorna `null` quando nenhum estado ativo
- **`src/hooks/useOfficeState.ts`** — `FETCH_START` action no reducer (seta `isLoading=true, error=null`), `retryCount` state, callback `retry()`
- **`src/App.tsx`** — monta `<OfficeOverlay>` com props do hook
- **Testes** — 11 testes unitários para `OfficeOverlay`, 2 novos testes de `retry` em `useOfficeState`

### Resultado

- 158 unit tests passando (14 arquivos)
- 13 E2E Playwright passando
- `tsc --noEmit` limpo

closes #69