### PR TITLE
feat(ui): error boundary em App.tsx

### DIFF
--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ErrorBoundary } from './ErrorBoundary'
+
+/** Component that throws during render for testing purposes */
+function BombComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('test explosion')
+  return <div>all good</div>
+}
+
+// Suppress React's error boundary console output in tests
+const originalError = console.error
+beforeEach(() => {
+  console.error = vi.fn()
+})
+afterEach(() => {
+  console.error = originalError
+})
+
+describe('ErrorBoundary — no error', () => {
+  it('renders children when no error is thrown', () => {
+    render(
+      <ErrorBoundary>
+        <BombComponent shouldThrow={false} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('all good')).toBeTruthy()
+  })
+})
+
+describe('ErrorBoundary — error caught', () => {
+  it('renders alert with aria-label when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <BombComponent shouldThrow={true} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByLabelText('application error')).toBeTruthy()
+  })
+
+  it('shows the error message', () => {
+    render(
+      <ErrorBoundary>
+        <BombComponent shouldThrow={true} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('test explosion')).toBeTruthy()
+  })
+
+  it('shows something went wrong heading', () => {
+    render(
+      <ErrorBoundary>
+        <BombComponent shouldThrow={true} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText(/something went wrong/i)).toBeTruthy()
+  })
+
+  it('renders reload button', () => {
+    render(
+      <ErrorBoundary>
+        <BombComponent shouldThrow={true} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByRole('button', { name: /reload application/i })).toBeTruthy()
+  })
+
+  it('does not render children when error is thrown', () => {
+    render(
+      <ErrorBoundary>
+        <BombComponent shouldThrow={true} />
+      </ErrorBoundary>
+    )
+    expect(screen.queryByText('all good')).toBeNull()
+  })
+})
+
+describe('ErrorBoundary — custom fallback', () => {
+  it('renders custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={(err) => <p>custom: {err.message}</p>}>
+        <BombComponent shouldThrow={true} />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('custom: test explosion')).toBeTruthy()
+  })
+
+  it('does not render default alert when custom fallback is used', () => {
+    render(
+      <ErrorBoundary fallback={() => <p>custom ui</p>}>
+        <BombComponent shouldThrow={true} />
+      </ErrorBoundary>
+    )
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('ErrorBoundary — reload button', () => {
+  it('calls window.location.reload when reload button is clicked', () => {
+    const reload = vi.fn()
+    vi.stubGlobal('location', { reload })
+
+    render(
+      <ErrorBoundary>
+        <BombComponent shouldThrow={true} />
+      </ErrorBoundary>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /reload application/i }))
+    expect(reload).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,100 @@
+import { Component } from 'react'
+import type { ReactNode, ErrorInfo } from 'react'
+import { COLORS } from '../constants/theme'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  /** Optional fallback UI — receives the error. Defaults to built-in fallback. */
+  fallback?: (error: Error) => ReactNode
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+}
+
+const STYLES = {
+  root: {
+    position: 'fixed',
+    inset: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+    background: COLORS.bg,
+    fontFamily: 'JetBrains Mono, monospace',
+    color: COLORS.label,
+  } as React.CSSProperties,
+
+  title: {
+    fontSize: 14,
+    letterSpacing: '0.08em',
+    color: '#ef4444',
+    margin: 0,
+  } as React.CSSProperties,
+
+  message: {
+    fontSize: 11,
+    color: COLORS.labelMuted,
+    maxWidth: 480,
+    textAlign: 'center',
+    lineHeight: 1.6,
+    margin: 0,
+  } as React.CSSProperties,
+
+  reloadBtn: {
+    marginTop: 8,
+    background: 'none',
+    border: `1px solid ${COLORS.zoneBorder}`,
+    borderRadius: 4,
+    color: COLORS.label,
+    fontSize: 11,
+    padding: '6px 18px',
+    cursor: 'pointer',
+    fontFamily: 'JetBrains Mono, monospace',
+    letterSpacing: '0.06em',
+  } as React.CSSProperties,
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Log for debugging — can be replaced with a real error reporting service
+    console.error('[ErrorBoundary] Uncaught error:', error, info.componentStack)
+  }
+
+  handleReload = (): void => {
+    window.location.reload()
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    const { children, fallback } = this.props
+
+    if (!error) return children
+
+    if (fallback) return fallback(error)
+
+    return (
+      <div role="alert" aria-label="application error" style={STYLES.root}>
+        <p style={STYLES.title}>⚠ something went wrong</p>
+        <p style={STYLES.message}>{error.message}</p>
+        <button
+          aria-label="reload application"
+          onClick={this.handleReload}
+          style={STYLES.reloadBtn}
+        >
+          reload
+        </button>
+      </div>
+    )
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,15 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
+import { ErrorBoundary } from './components/ErrorBoundary'
 
 const root = document.getElementById('root')
 if (!root) throw new Error('Root element not found')
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>
 )


### PR DESCRIPTION
## O que foi feito

Adiciona `ErrorBoundary` — class component React que captura erros de renderização não tratados e exibe uma tela de fallback amigável.

### Mudanças

- **`src/components/ErrorBoundary.tsx`** — novo componente com:
  - `getDerivedStateFromError` e `componentDidCatch`
  - Fallback padrão: `role="alert"` + mensagem de erro + botão "reload" (`window.location.reload()`)
  - Prop opcional `fallback: (error: Error) => ReactNode` para UI customizada
- **`src/main.tsx`** — `<ErrorBoundary>` wrapping `<App>` dentro do `StrictMode`
- **`src/components/ErrorBoundary.test.tsx`** — 9 testes cobrindo:
  - Renderiza filhos quando não há erro
  - Exibe `role="alert"` + mensagem ao capturar erro
  - Fallback customizado via prop
  - Botão reload chama `window.location.reload()`

### Resultado

- 176 unit tests passando (15 arquivos)
- 15 E2E Playwright passando
- `tsc --noEmit` limpo

closes #73