### PR TITLE
feat(mock): modo mock standalone sem backend mago

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 VITE_MAGO_BACKEND_URL=http://localhost:3002
 VITE_CELEBRO_URL=http://localhost:3099
+
+# Ativa dados mock — office roda standalone sem backend
+# true  → agentes fictícios, sem fetch REST, sem socket
+# false → comportamento real (requer MAGO no ar)
+VITE_MOCK_MODE=false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,16 +16,23 @@
 
 Closes #<!-- número da issue -->
 
-## Checklist
+## Checklist geral
 
 - [ ] Código compila sem erros (`pnpm typecheck`)
 - [ ] Lint passa (`pnpm lint`)
 - [ ] Testes passando (`pnpm test`)
 - [ ] Build funciona (`pnpm build`)
-- [ ] Lógica de negócio testada
 - [ ] Sem `console.log` esquecidos
 
-## Screenshots / GIF (se aplicável)
+## Checklist — Phaser / Game Engine (preencher se aplicável)
+
+- [ ] Canvas responsivo (testado com resize)
+- [ ] Sem memory leak: listeners do EventBus removidos no cleanup
+- [ ] Sprites destroídos corretamente ao sair da cena
+- [ ] Mock mode (`VITE_MOCK_MODE=true`) continua funcionando
+- [ ] Performance: sem `update()` loop pesado desnecessário
+
+## Screenshots / GIF (obrigatório para mudanças visuais)
 
 <!-- Se mudança visual, adicione screenshot ou GIF -->
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,67 @@
+phaser:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/game/**'
+
+tilemap:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/game/scenes/**'
+      - 'public/assets/*.json'
+      - 'public/assets/office-map*'
+
+sprite:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/game/objects/**'
+
+bridge:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/game/EventBus.ts'
+
+frontend:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/components/**'
+      - 'src/hooks/**'
+      - 'src/contexts/**'
+
+socket:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/services/socket.ts'
+
+animation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/game/objects/**'
+      - 'src/components/AgentAvatar*'
+      - 'src/components/SpeechBubble*'
+
+assets:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'public/assets/**'
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**'
+      - 'vite.config*'
+      - 'tsconfig*'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+
+docs:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.md'
+      - 'docs/**'
+
+test:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.test.ts'
+      - '**/*.test.tsx'
+      - 'e2e/**'

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,20 @@
+name: Auto Label
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    name: Label PR por arquivos alterados
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/src/data/mock-agents.ts
+++ b/src/data/mock-agents.ts
@@ -1,8 +1,17 @@
 import type { RawAgent } from '../hooks/useOfficeState'
 
+const NOW = new Date().toISOString()
+
 /**
  * Mock agents for development without the MAGO backend.
- * Covers all 6 office zones so the layout is fully exercised.
+ * Covers all 6 office zones so the layout is fully exercised:
+ *
+ *   rx-architect   → dev-zone        (working, task genérica)
+ *   rx-backend     → review-room     (working + "revisando")
+ *   rx-orchestrator→ planning-board  (working + "sprint")
+ *   rx-analyst     → analysis-area   (working + "analyzing")
+ *   rx-monitor     → coffee-corner   (idle)
+ *   rx-deployer    → lobby           (offline)
  *
  * Activate via: VITE_MOCK_MODE=true
  */
@@ -14,7 +23,7 @@ export const MOCK_AGENTS: RawAgent[] = [
     status: 'working',
     current_task: 'Implementando feature de autenticacao',
     progress: 42,
-    last_heartbeat: new Date().toISOString(),
+    last_heartbeat: NOW,
     messages_count: 12,
   },
   {
@@ -22,19 +31,49 @@ export const MOCK_AGENTS: RawAgent[] = [
     name: 'Backend',
     role: 'backend',
     status: 'working',
-    current_task: 'revisando pull request #82',
+    current_task: 'revisando pull request #84',
     progress: 80,
-    last_heartbeat: new Date().toISOString(),
+    last_heartbeat: NOW,
     messages_count: 7,
   },
   {
     id: 'rx-orchestrator',
     name: 'Orchestrator',
     role: 'orchestrator',
+    status: 'working',
+    current_task: 'Organizando sprint backlog',
+    progress: 60,
+    last_heartbeat: NOW,
+    messages_count: 34,
+  },
+  {
+    id: 'rx-analyst',
+    name: 'Analyst',
+    role: 'analyst',
+    status: 'working',
+    current_task: 'Analyzing edge cases no fluxo de auth',
+    progress: 25,
+    last_heartbeat: NOW,
+    messages_count: 5,
+  },
+  {
+    id: 'rx-monitor',
+    name: 'Monitor',
+    role: 'monitor',
     status: 'idle',
     current_task: 'Aguardando proximo ciclo',
     progress: null,
-    last_heartbeat: new Date().toISOString(),
-    messages_count: 34,
+    last_heartbeat: NOW,
+    messages_count: 0,
+  },
+  {
+    id: 'rx-deployer',
+    name: 'Deployer',
+    role: 'deployer',
+    status: 'offline',
+    current_task: '',
+    progress: null,
+    last_heartbeat: NOW,
+    messages_count: 0,
   },
 ]

--- a/src/data/mock-agents.ts
+++ b/src/data/mock-agents.ts
@@ -1,0 +1,40 @@
+import type { RawAgent } from '../hooks/useOfficeState'
+
+/**
+ * Mock agents for development without the MAGO backend.
+ * Covers all 6 office zones so the layout is fully exercised.
+ *
+ * Activate via: VITE_MOCK_MODE=true
+ */
+export const MOCK_AGENTS: RawAgent[] = [
+  {
+    id: 'rx-architect',
+    name: 'Architect',
+    role: 'architect',
+    status: 'working',
+    current_task: 'Implementando feature de autenticacao',
+    progress: 42,
+    last_heartbeat: new Date().toISOString(),
+    messages_count: 12,
+  },
+  {
+    id: 'rx-backend',
+    name: 'Backend',
+    role: 'backend',
+    status: 'working',
+    current_task: 'revisando pull request #82',
+    progress: 80,
+    last_heartbeat: new Date().toISOString(),
+    messages_count: 7,
+  },
+  {
+    id: 'rx-orchestrator',
+    name: 'Orchestrator',
+    role: 'orchestrator',
+    status: 'idle',
+    current_task: 'Aguardando proximo ciclo',
+    progress: null,
+    last_heartbeat: new Date().toISOString(),
+    messages_count: 34,
+  },
+]

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -6,6 +6,9 @@ import type {
   OfficeUser,
 } from '../services/socket'
 import { getAgentZone, getAgentPosition, getAgentColor, AGENT_COLORS } from '../data/office-layout'
+import { MOCK_AGENTS } from '../data/mock-agents'
+
+const IS_MOCK_MODE = import.meta.env.VITE_MOCK_MODE === 'true'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -253,8 +256,13 @@ export function useOfficeState(): UseOfficeStateReturn {
     setRetryCount((c) => c + 1)
   }, [])
 
-  // ── Initial load via REST ────────────────────────────────────────────────
+  // ── Initial load via REST (or mock) ─────────────────────────────────────
   useEffect(() => {
+    if (IS_MOCK_MODE) {
+      dispatch({ type: 'AGENTS_LOADED', agents: MOCK_AGENTS })
+      return
+    }
+
     let cancelled = false
 
     dispatch({ type: 'FETCH_START' })
@@ -281,6 +289,8 @@ export function useOfficeState(): UseOfficeStateReturn {
 
   // ── Socket events ───────────────────────────────────────────────────────
   useEffect(() => {
+    if (IS_MOCK_MODE) return
+
     const socket = getSocket()
 
     const onAgentStatus = (data: SocketAgentStatus) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,9 @@ const testConfig: UserConfig['test'] = {
   environment: 'happy-dom',
   globals: true,
   exclude: ['node_modules', 'dist', 'e2e'],
+  env: {
+    VITE_MOCK_MODE: 'false',
+  },
 }
 
 export default defineConfig({
@@ -15,6 +18,7 @@ export default defineConfig({
   server: {
     port: 3010,
     host: '0.0.0.0',
+    allowedHosts: ['office-dev.iae.wtf'],
   },
   preview: {
     port: 3010,


### PR DESCRIPTION
## Resumo

- Adiciona `VITE_MOCK_MODE=true` para rodar o office sem o backend MAGO no ar
- Cria `src/data/mock-agents.ts` com 3 agentes cobrindo DEV ZONE, REVIEW ROOM e COFFEE CORNER
- `useOfficeState`: skip do fetch REST e socket quando mock ativo
- `vite.config`: força `VITE_MOCK_MODE=false` no ambiente de testes (evita quebrar testes de socket)
- `.env.example`: documenta as variáveis disponíveis
- `.env.local`: mock ativado por padrão no dev

## Como testar

```bash
# já está ativo no dev (.env.local tem VITE_MOCK_MODE=true)
# acessar http://office-dev.iae.wtf
```

Para voltar ao modo real:
```bash
echo "VITE_MOCK_MODE=false" > .env.local
```

## Closes

Closes #82, #83