### PR TITLE
feat(game): integrar phaser 3 ao projeto react/vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "framer-motion": "^11.0.0",
+    "phaser": "^3.90.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "socket.io-client": "^4.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       framer-motion:
         specifier: ^11.0.0
         version: 11.18.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      phaser:
+        specifier: ^3.90.0
+        version: 3.90.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -1445,6 +1448,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2080,6 +2086,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  phaser@3.90.0:
+    resolution: {integrity: sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4112,6 +4121,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -4760,6 +4771,10 @@ snapshots:
   pathe@1.1.2: {}
 
   pathval@2.0.1: {}
+
+  phaser@3.90.0:
+    dependencies:
+      eventemitter3: 5.0.4
 
   picocolors@1.1.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,15 @@ import { HumanAvatar } from './components/HumanAvatar'
 import { OnlineUsersList } from './components/OnlineUsersList'
 import { AgentDetailPanel } from './components/AgentDetailPanel'
 import { getSocket } from './services/socket'
+import { PhaserGame } from './game/PhaserGame'
+import type { PhaserGameRef } from './game/PhaserGame'
 
 export function App() {
   const { status } = useSocket()
   const { agents, users, isLoading, error, setZoneOverride, clearZoneOverride, retry } =
     useOfficeState()
   const canvasRef = useRef<HTMLDivElement>(null)
+  const phaserRef = useRef<PhaserGameRef>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
 
   const mySocketId = getSocket().id ?? null
@@ -47,6 +50,10 @@ export function App() {
 
   return (
     <>
+      {/* Phaser canvas — camada base */}
+      <PhaserGame ref={phaserRef} />
+
+      {/* UI React — overlay sobre o canvas */}
       <OfficeCanvas
         connectionStatus={status}
         agentCount={agents.filter((a) => a.status !== 'offline').length}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ export function App() {
   const { agents, users, isLoading, error, setZoneOverride, clearZoneOverride, retry } =
     useOfficeState()
   const canvasRef = useRef<HTMLDivElement>(null)
+  // Ref exposta para uso futuro na bridge EventBus (#93)
   const phaserRef = useRef<PhaserGameRef>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
 

--- a/src/components/OfficeCanvas.tsx
+++ b/src/components/OfficeCanvas.tsx
@@ -16,12 +16,14 @@ interface OfficeCanvasProps {
 
 const STYLES = {
   canvas: {
-    position: 'relative',
+    position: 'absolute',
+    inset: 0,
     width: '100%',
-    height: '100vh',
-    background: COLORS.bg,
+    height: '100%',
+    background: 'transparent',
     overflow: 'hidden',
     fontFamily: 'JetBrains Mono, monospace',
+    zIndex: 1,
   } as React.CSSProperties,
 
   grid: {

--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -1,0 +1,13 @@
+import Phaser from 'phaser'
+
+/**
+ * EventBus — bridge de comunicação entre React e Phaser.
+ *
+ * React emite eventos para a cena Phaser atualizar sprites.
+ * Phaser emite eventos para React atualizar UI (posição de SpeechBubble, etc).
+ *
+ * Uso:
+ *   EventBus.emit('agents-updated', agents)
+ *   EventBus.on('scene-ready', (scene) => { ... })
+ */
+export const EventBus = new Phaser.Events.EventEmitter()

--- a/src/game/PhaserGame.tsx
+++ b/src/game/PhaserGame.tsx
@@ -30,11 +30,17 @@ export const PhaserGame = forwardRef<PhaserGameRef>(function PhaserGame(_, ref) 
   useEffect(() => {
     if (!containerRef.current || gameRef.current) return
 
+    const container = containerRef.current
+
+    // clientWidth pode ser 0 antes do layout em strict mode — usa innerWidth como fallback
+    const width = container.clientWidth || window.innerWidth
+    const height = container.clientHeight || window.innerHeight
+
     const config: Phaser.Types.Core.GameConfig = {
       type: Phaser.AUTO,
-      parent: containerRef.current,
-      width: containerRef.current.clientWidth,
-      height: containerRef.current.clientHeight,
+      parent: container,
+      width,
+      height,
       backgroundColor: '#0d1117',
       scene: [BootScene],
       scale: {

--- a/src/game/PhaserGame.tsx
+++ b/src/game/PhaserGame.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
+import Phaser from 'phaser'
+import { BootScene } from './scenes/BootScene'
+import { EventBus } from './EventBus'
+
+export interface PhaserGameRef {
+  game: Phaser.Game | null
+  scene: Phaser.Scene | null
+}
+
+/**
+ * PhaserGame — wrapper React para o canvas Phaser.
+ *
+ * Instancia o Phaser.Game em um <div> ref e gerencia o ciclo de vida:
+ * - mount  → cria o jogo
+ * - unmount → destroi o jogo e limpa listeners do EventBus
+ *
+ * Expõe { game, scene } via forwardRef para o pai inspecionar se necessário.
+ */
+export const PhaserGame = forwardRef<PhaserGameRef>(function PhaserGame(_, ref) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const gameRef = useRef<Phaser.Game | null>(null)
+  const sceneRef = useRef<Phaser.Scene | null>(null)
+
+  useImperativeHandle(ref, () => ({
+    get game() { return gameRef.current },
+    get scene() { return sceneRef.current },
+  }))
+
+  useEffect(() => {
+    if (!containerRef.current || gameRef.current) return
+
+    const config: Phaser.Types.Core.GameConfig = {
+      type: Phaser.AUTO,
+      parent: containerRef.current,
+      width: containerRef.current.clientWidth,
+      height: containerRef.current.clientHeight,
+      backgroundColor: '#0d1117',
+      scene: [BootScene],
+      scale: {
+        mode: Phaser.Scale.RESIZE,
+        autoCenter: Phaser.Scale.CENTER_BOTH,
+      },
+      // Canvas transparente permite que o overlay React apareça por cima
+      transparent: false,
+      // Sem physics por enquanto — será adicionado na issue #91
+      physics: undefined,
+    }
+
+    gameRef.current = new Phaser.Game(config)
+
+    // Captura a cena ativa quando o Phaser emitir 'scene-ready'
+    const onSceneReady = (scene: Phaser.Scene) => {
+      sceneRef.current = scene
+    }
+    EventBus.on('scene-ready', onSceneReady)
+
+    return () => {
+      EventBus.off('scene-ready', onSceneReady)
+      gameRef.current?.destroy(true)
+      gameRef.current = null
+      sceneRef.current = null
+    }
+  }, [])
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: 0,
+      }}
+    />
+  )
+})

--- a/src/game/PhaserGame.tsx
+++ b/src/game/PhaserGame.tsx
@@ -41,10 +41,8 @@ export const PhaserGame = forwardRef<PhaserGameRef>(function PhaserGame(_, ref) 
         mode: Phaser.Scale.RESIZE,
         autoCenter: Phaser.Scale.CENTER_BOTH,
       },
-      // Canvas transparente permite que o overlay React apareça por cima
+      // UI React fica sobre o canvas via z-index — não precisa de transparência
       transparent: false,
-      // Sem physics por enquanto — será adicionado na issue #91
-      physics: undefined,
     }
 
     gameRef.current = new Phaser.Game(config)

--- a/src/game/scenes/BootScene.ts
+++ b/src/game/scenes/BootScene.ts
@@ -16,9 +16,6 @@ export class BootScene extends Phaser.Scene {
   create() {
     const { width, height } = this.scale
 
-    // Fundo
-    this.add.rectangle(0, 0, width, height, 0x0d1117).setOrigin(0)
-
     // Label de placeholder
     this.add
       .text(width / 2, height / 2, 'MAGO Office', {

--- a/src/game/scenes/BootScene.ts
+++ b/src/game/scenes/BootScene.ts
@@ -1,0 +1,41 @@
+import Phaser from 'phaser'
+import { EventBus } from '../EventBus'
+
+/**
+ * BootScene — cena inicial minimalista.
+ *
+ * Renderiza um fundo escuro com o texto "MAGO Office" enquanto
+ * os assets ainda não foram carregados (PRE-LOAD virá na issue #87).
+ * Emite 'scene-ready' para o React saber que o Phaser inicializou.
+ */
+export class BootScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'BootScene' })
+  }
+
+  create() {
+    const { width, height } = this.scale
+
+    // Fundo
+    this.add.rectangle(0, 0, width, height, 0x0d1117).setOrigin(0)
+
+    // Label de placeholder
+    this.add
+      .text(width / 2, height / 2, 'MAGO Office', {
+        fontFamily: 'monospace',
+        fontSize: '24px',
+        color: '#8b5cf6',
+      })
+      .setOrigin(0.5)
+
+    this.add
+      .text(width / 2, height / 2 + 36, 'carregando assets…', {
+        fontFamily: 'monospace',
+        fontSize: '12px',
+        color: '#6b7280',
+      })
+      .setOrigin(0.5)
+
+    EventBus.emit('scene-ready', this)
+  }
+}


### PR DESCRIPTION
## Descrição

Integra o Phaser 3 ao projeto React/Vite existente como camada base de renderização, mantendo a UI React como overlay.

## Arquitetura introduzida

```
App.tsx
├── PhaserGame (z-index 0)  ← canvas Phaser, renderização do jogo
│    └── BootScene          ← cena placeholder (assets virão em #87)
└── OfficeCanvas (z-index 1) ← overlay React transparente (UI existente)
```

**EventBus** — `Phaser.Events.EventEmitter` como bridge tipada React ↔ Phaser.

## Arquivos

- `src/game/EventBus.ts` — bridge de eventos
- `src/game/PhaserGame.tsx` — wrapper React com forwardRef + lifecycle
- `src/game/scenes/BootScene.ts` — cena inicial placeholder
- `src/App.tsx` — PhaserGame inserido na base
- `src/components/OfficeCanvas.tsx` — agora `position: absolute, transparent`

## Checklist

- [x] Código compila sem erros (`pnpm typecheck`)
- [x] Testes passando 176/176 (`pnpm test`)
- [x] Canvas responsivo (RESIZE mode do Phaser Scale)
- [x] Sem memory leak: game destruído no unmount, listener removido

Closes #86