### PR TITLE
fix(e2e): substituir seletor de estilo por data-testid no canvas

### DIFF
--- a/e2e/office-agent-drag.spec.ts
+++ b/e2e/office-agent-drag.spec.ts
@@ -31,7 +31,7 @@ test.describe('agent drag to zone', () => {
 
   test('drag agent to another zone shows anchor badge', async ({ page }) => {
     const agent = page.getByLabel(/agent rx-architect/i)
-    const canvas = page.locator('[style*="height: 100vh"]').first()
+    const canvas = page.getByTestId('office-canvas')
 
     const agentBox = await agent.boundingBox()
     const canvasBox = await canvas.boundingBox()
@@ -53,7 +53,7 @@ test.describe('agent drag to zone', () => {
 
   test('reset button appears after drag and clears override on click', async ({ page }) => {
     const agent = page.getByLabel(/agent rx-architect/i)
-    const canvas = page.locator('[style*="height: 100vh"]').first()
+    const canvas = page.getByTestId('office-canvas')
 
     const agentBox = await agent.boundingBox()
     const canvasBox = await canvas.boundingBox()

--- a/src/components/OfficeCanvas.tsx
+++ b/src/components/OfficeCanvas.tsx
@@ -44,7 +44,7 @@ export function OfficeCanvas({
   canvasRef,
 }: OfficeCanvasProps) {
   return (
-    <div ref={canvasRef} style={STYLES.canvas}>
+    <div ref={canvasRef} style={STYLES.canvas} data-testid="office-canvas">
       {/* Decorative grid */}
       <div style={STYLES.grid} />
 


### PR DESCRIPTION
## Problema

O seletor `[style*="height: 100vh"]` usado em `office-agent-drag.spec.ts` quebrou após a PR #100 (Phaser), que alterou `OfficeCanvas` de `height: 100vh` para `height: 100%`.

## Solução

- Adiciona `data-testid="office-canvas"` ao elemento raiz do `OfficeCanvas`
- Substitui o seletor frágil por `page.getByTestId('office-canvas')` nos dois testes afetados

## Checklist

- [x] Typecheck passando
- [x] Seletor estável — não depende de valores CSS