### PR TITLE
feat(tilemap): OfficeScene com tilemap e zone-markers

### DIFF
--- a/public/assets/office-map.json
+++ b/public/assets/office-map.json
@@ -61,8 +61,17 @@
   "tileheight": 16,
   "tilesets": [
     {
+      "columns": 1,
       "firstgid": 1,
-      "source": "tileset-placeholder.json"
+      "image": "agent-placeholder.png",
+      "imageheight": 16,
+      "imagewidth": 16,
+      "margin": 0,
+      "name": "tileset-placeholder",
+      "spacing": 0,
+      "tilecount": 1,
+      "tileheight": 16,
+      "tilewidth": 16
     }
   ],
   "tilewidth": 16,

--- a/src/game/scenes/OfficeScene.ts
+++ b/src/game/scenes/OfficeScene.ts
@@ -2,37 +2,84 @@ import Phaser from 'phaser'
 import { EventBus } from '../EventBus'
 
 /**
- * OfficeScene — cena principal do jogo.
+ * OfficeScene — cena principal do jogo (#88).
  *
- * Nesta issue (#87) é um placeholder que confirma a transição do PreloadScene.
- * Será expandida em #88 (tilemap + câmera) e #92 (AgentSprite).
+ * Carrega o tilemap office-map.json, renderiza a camada floor,
+ * lê os objetos da camada zone-markers e expõe getZoneCenterWorld()
+ * para AgentSprite (#92) posicionar personagens por zoneId.
  *
  * Fluxo: PreloadScene → OfficeScene
  */
+
+export type ZoneId =
+  | 'dev-zone'
+  | 'review-room'
+  | 'planning-board'
+  | 'analysis-area'
+  | 'coffee-corner'
+  | 'lobby'
+
 export class OfficeScene extends Phaser.Scene {
+  private zoneRects = new Map<string, Phaser.Geom.Rectangle>()
+
   constructor() {
     super({ key: 'OfficeScene' })
   }
 
   create() {
-    const { width, height } = this.scale
+    const map = this.make.tilemap({ key: 'office-map' })
 
-    this.add
-      .text(width / 2, height / 2, 'Office Scene', {
-        fontFamily: 'monospace',
-        fontSize: '20px',
-        color: '#8b5cf6',
-      })
-      .setOrigin(0.5)
+    // Adiciona o tileset placeholder (será substituído em #89)
+    const tileset = map.addTilesetImage('tileset-placeholder', 'tile-placeholder')
 
-    this.add
-      .text(width / 2, height / 2 + 28, 'assets carregados — mapa em breve (#88)', {
-        fontFamily: 'monospace',
-        fontSize: '11px',
-        color: '#4b5563',
-      })
-      .setOrigin(0.5)
+    if (tileset) {
+      map.createLayer('floor', tileset, 0, 0)
+    }
+
+    this.parseZoneMarkers(map)
+    this.setupCamera(map)
 
     EventBus.emit('scene-ready', this)
+  }
+
+  /** Retorna o centro em pixels de uma zona pelo seu zoneId. */
+  getZoneCenterWorld(zoneId: string): { x: number; y: number } | null {
+    const rect = this.zoneRects.get(zoneId)
+    if (!rect) return null
+    return { x: rect.centerX, y: rect.centerY }
+  }
+
+  private parseZoneMarkers(map: Phaser.Tilemaps.Tilemap) {
+    const objectLayer = map.getObjectLayer('zone-markers')
+    if (!objectLayer) return
+
+    for (const obj of objectLayer.objects) {
+      const zoneIdProp = obj.properties?.find(
+        (p: { name: string; value: unknown }) => p.name === 'zoneId',
+      )
+      if (!zoneIdProp) continue
+
+      const zoneId = zoneIdProp.value as string
+      const rect = new Phaser.Geom.Rectangle(
+        obj.x ?? 0,
+        obj.y ?? 0,
+        obj.width ?? 0,
+        obj.height ?? 0,
+      )
+      this.zoneRects.set(zoneId, rect)
+    }
+  }
+
+  private setupCamera(map: Phaser.Tilemaps.Tilemap) {
+    const cam = this.cameras.main
+    cam.setBounds(0, 0, map.widthInPixels, map.heightInPixels)
+
+    // Centraliza o mapa no viewport inicial
+    cam.centerOn(map.widthInPixels / 2, map.heightInPixels / 2)
+
+    // Re-centraliza ao redimensionar a janela
+    this.scale.on(Phaser.Scale.Events.RESIZE, () => {
+      cam.centerOn(map.widthInPixels / 2, map.heightInPixels / 2)
+    })
   }
 }


### PR DESCRIPTION
## Resumo

Implementa a `OfficeScene` principal substituindo o placeholder (#87).

- Carrega `office-map.json` via `make.tilemap` e renderiza camada `floor`
- Lê objectgroup `zone-markers` → `Map<zoneId, Phaser.Geom.Rectangle>`
- Exporta `getZoneCenterWorld(zoneId)` para `AgentSprite` em #92
- Configura câmera com `setBounds` nos limites do mapa + `centerOn` no `RESIZE`
- Emite `scene-ready` no `EventBus` ao finalizar `create()`
- Incorpora tileset-placeholder inline no `office-map.json` (fix Phaser external tileset)

Closes #88

## Test plan

- [ ] TypeScript sem erros (`pnpm typecheck`)
- [ ] 176 testes passando (`pnpm test`)
- [ ] Canvas renderiza tilemap (tile roxo, 20×20) em `office-dev.iae.wtf`
- [ ] Console sem erros de asset não encontrado