### PR TITLE
chore(game): quick fixes agrupados #80 #101 #102 #103

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 coverage/
 *.log
 .DS_Store
+*.tsbuildinfo

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,8 @@ export default [
         AbortController: 'readonly',
         KeyboardEvent: 'readonly',
         localStorage: 'readonly',
+        requestAnimationFrame: 'readonly',
+        cancelAnimationFrame: 'readonly',
         React: 'readonly',
         JSX: 'readonly',
         import: 'readonly',

--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -1,13 +1,57 @@
 import Phaser from 'phaser'
+import type { AgentOfficeData } from '../hooks/useOfficeState'
 
 /**
- * EventBus — bridge de comunicação entre React e Phaser.
+ * Mapa de eventos do EventBus com tipos completos (#103).
  *
- * React emite eventos para a cena Phaser atualizar sprites.
- * Phaser emite eventos para React atualizar UI (posição de SpeechBubble, etc).
+ * React emite → Phaser consome:
+ *   agents-updated   — sincroniza AgentSprites com estado atual
  *
- * Uso:
- *   EventBus.emit('agents-updated', agents)
- *   EventBus.on('scene-ready', (scene) => { ... })
+ * Phaser emite → React consome:
+ *   scene-ready      — OfficeScene pronta para receber comandos
+ *   agent-speech-position — posição em tela do balão de fala
+ *   human-moved      — posição do HumanSprite (para emitir via socket)
  */
-export const EventBus = new Phaser.Events.EventEmitter()
+export interface OfficeEventMap {
+  'scene-ready': [scene: Phaser.Scene]
+  'agents-updated': [agents: AgentOfficeData[]]
+  'agent-speech': [agentId: string, text: string]
+  'agent-speech-position': [agentId: string, x: number, y: number]
+  'human-moved': [x: number, y: number]
+}
+
+/** Wrapper tipado sobre Phaser.Events.EventEmitter. */
+class TypedEventBus {
+  private readonly emitter = new Phaser.Events.EventEmitter()
+
+  on<K extends keyof OfficeEventMap>(
+    event: K,
+    fn: (...args: OfficeEventMap[K]) => void,
+  ): this {
+    this.emitter.on(event as string, fn)
+    return this
+  }
+
+  once<K extends keyof OfficeEventMap>(
+    event: K,
+    fn: (...args: OfficeEventMap[K]) => void,
+  ): this {
+    this.emitter.once(event as string, fn)
+    return this
+  }
+
+  off<K extends keyof OfficeEventMap>(
+    event: K,
+    fn: (...args: OfficeEventMap[K]) => void,
+  ): this {
+    this.emitter.off(event as string, fn)
+    return this
+  }
+
+  emit<K extends keyof OfficeEventMap>(event: K, ...args: OfficeEventMap[K]): this {
+    this.emitter.emit(event as string, ...args)
+    return this
+  }
+}
+
+export const EventBus = new TypedEventBus()

--- a/src/game/PhaserGame.tsx
+++ b/src/game/PhaserGame.tsx
@@ -34,26 +34,30 @@ export const PhaserGame = forwardRef<PhaserGameRef>(function PhaserGame(_, ref) 
 
     const container = containerRef.current
 
-    // clientWidth pode ser 0 antes do layout em strict mode — usa innerWidth como fallback
-    const width = container.clientWidth || window.innerWidth
-    const height = container.clientHeight || window.innerHeight
+    // rAF garante layout calculado antes de ler clientWidth (#101)
+    const raf = requestAnimationFrame(() => {
+      if (gameRef.current) return
 
-    const config: Phaser.Types.Core.GameConfig = {
-      type: Phaser.AUTO,
-      parent: container,
-      width,
-      height,
-      backgroundColor: '#0d1117',
-      scene: [BootScene, PreloadScene, OfficeScene],
-      scale: {
-        mode: Phaser.Scale.RESIZE,
-        autoCenter: Phaser.Scale.CENTER_BOTH,
-      },
-      // UI React fica sobre o canvas via z-index — não precisa de transparência
-      transparent: false,
-    }
+      const width = container.clientWidth || window.innerWidth
+      const height = container.clientHeight || window.innerHeight
 
-    gameRef.current = new Phaser.Game(config)
+      const config: Phaser.Types.Core.GameConfig = {
+        type: Phaser.AUTO,
+        parent: container,
+        width,
+        height,
+        backgroundColor: '#0d1117',
+        scene: [BootScene, PreloadScene, OfficeScene],
+        scale: {
+          mode: Phaser.Scale.RESIZE,
+          autoCenter: Phaser.Scale.CENTER_BOTH,
+        },
+        // UI React fica sobre o canvas via z-index — não precisa de transparência
+        transparent: false,
+      }
+
+      gameRef.current = new Phaser.Game(config)
+    })
 
     // Captura a cena ativa quando o Phaser emitir 'scene-ready'
     const onSceneReady = (scene: Phaser.Scene) => {
@@ -62,6 +66,7 @@ export const PhaserGame = forwardRef<PhaserGameRef>(function PhaserGame(_, ref) 
     EventBus.on('scene-ready', onSceneReady)
 
     return () => {
+      cancelAnimationFrame(raf)
       EventBus.off('scene-ready', onSceneReady)
       gameRef.current?.destroy(true)
       gameRef.current = null

--- a/tsconfig.app.tsbuildinfo
+++ b/tsconfig.app.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/App.tsx","./src/main.tsx","./src/components/OfficeCanvas.tsx","./src/components/OfficeHUD.tsx","./src/components/OfficeRoom.tsx","./src/data/office-layout.test.ts","./src/data/office-layout.ts","./src/hooks/useSocket.test.ts","./src/hooks/useSocket.ts","./src/services/socket.ts"],"version":"5.9.3"}


### PR DESCRIPTION
## Resumo

Agrupa 4 fixes independentes de baixo risco.

| Issue | Fix |
|-------|-----|
| #80 | `*.tsbuildinfo` adicionado ao `.gitignore` + `git rm --cached` |
| #101 | Init do Phaser movido para `requestAnimationFrame` — garante `clientWidth` calculado no strict mode |
| #102 | Rectangle redundante no `BootScene` já removido no PR #100 — fechando a issue |
| #103 | `EventBus` tipado com `OfficeEventMap` + wrapper `TypedEventBus` sobre `Phaser.Events.EventEmitter` |

Closes #80
Closes #101
Closes #102
Closes #103

## Test plan

- [ ] `pnpm typecheck` sem erros
- [ ] 176 testes passando
- [ ] `tsconfig.app.tsbuildinfo` não aparece mais no `git status`
- [ ] Canvas carrega sem flash de tamanho errado
- [ ] EventBus com autocomplete tipado nos eventos