### PR TITLE
feat(tilemap): collision layers e getZoneBounds

### DIFF
--- a/src/components/OfficeRoom.test.tsx
+++ b/src/components/OfficeRoom.test.tsx
@@ -13,6 +13,10 @@ const mockZone: Zone = {
   height: 25,
   color: '#1a1a2e',
   description: 'Test zone',
+  worldX: 16,
+  worldY: 32,
+  worldW: 160,
+  worldH: 192,
 }
 
 describe('OfficeRoom', () => {

--- a/src/data/office-layout.ts
+++ b/src/data/office-layout.ts
@@ -2,12 +2,17 @@ export interface Zone {
   id: string
   label: string
   icon: string
-  x: number // % from left
-  y: number // % from top
-  width: number // % width
-  height: number // % height
+  x: number // % from left (CSS layout)
+  y: number // % from top  (CSS layout)
+  width: number // % width  (CSS layout)
+  height: number // % height (CSS layout)
   color: string // background (dark theme)
   description: string
+  /** Coordenadas em pixels no tilemap (office-map.json, 16px/tile) — usadas pelo Phaser (#91) */
+  worldX: number
+  worldY: number
+  worldW: number
+  worldH: number
 }
 
 export const OFFICE_ZONES: Zone[] = [
@@ -15,67 +20,55 @@ export const OFFICE_ZONES: Zone[] = [
     id: 'dev-zone',
     label: 'Dev Zone',
     icon: '⚡',
-    x: 2,
-    y: 5,
-    width: 28,
-    height: 30,
+    x: 2, y: 5, width: 28, height: 30,
     color: '#1e1b4b',
     description: 'Implementation and development',
+    worldX: 16, worldY: 32, worldW: 160, worldH: 192,
   },
   {
     id: 'review-room',
     label: 'Review Room',
     icon: '👁',
-    x: 34,
-    y: 5,
-    width: 28,
-    height: 30,
+    x: 34, y: 5, width: 28, height: 30,
     color: '#1a2035',
     description: 'Code review and quality analysis',
+    worldX: 192, worldY: 32, worldW: 160, worldH: 192,
   },
   {
     id: 'planning-board',
     label: 'Planning Board',
     icon: '📋',
-    x: 66,
-    y: 5,
-    width: 30,
-    height: 30,
+    x: 66, y: 5, width: 30, height: 30,
     color: '#1f1635',
     description: 'Sprint planning and task management',
+    worldX: 368, worldY: 32, worldW: 160, worldH: 192,
   },
   {
     id: 'analysis-area',
     label: 'Analysis Area',
     icon: '🔍',
-    x: 2,
-    y: 42,
-    width: 44,
-    height: 30,
+    x: 2, y: 42, width: 44, height: 30,
     color: '#0f2027',
     description: 'Problem analysis and edge cases',
+    worldX: 16, worldY: 240, worldW: 256, worldH: 192,
   },
   {
     id: 'coffee-corner',
     label: 'Coffee Corner',
     icon: '☕',
-    x: 50,
-    y: 42,
-    width: 46,
-    height: 30,
+    x: 50, y: 42, width: 46, height: 30,
     color: '#1a0f0f',
     description: 'Idle agents rest here',
+    worldX: 288, worldY: 240, worldW: 256, worldH: 192,
   },
   {
     id: 'lobby',
     label: 'Lobby',
     icon: '🚪',
-    x: 2,
-    y: 78,
-    width: 94,
-    height: 18,
+    x: 2, y: 78, width: 94, height: 18,
     color: '#0d1117',
     description: 'Entrance — humans and offline agents',
+    worldX: 16, worldY: 448, worldW: 512, worldH: 96,
   },
 ]
 

--- a/src/game/PhaserGame.tsx
+++ b/src/game/PhaserGame.tsx
@@ -52,6 +52,11 @@ export const PhaserGame = forwardRef<PhaserGameRef>(function PhaserGame(_, ref) 
           mode: Phaser.Scale.RESIZE,
           autoCenter: Phaser.Scale.CENTER_BOTH,
         },
+        // Arcade Physics para colisão de sprites com layers (#91)
+        physics: {
+          default: 'arcade',
+          arcade: { gravity: { x: 0, y: 0 }, debug: false },
+        },
         // UI React fica sobre o canvas via z-index — não precisa de transparência
         transparent: false,
       }

--- a/src/game/scenes/OfficeScene.ts
+++ b/src/game/scenes/OfficeScene.ts
@@ -2,14 +2,14 @@ import Phaser from 'phaser'
 import { EventBus } from '../EventBus'
 
 /**
- * OfficeScene — cena principal do jogo (#88, expandida em #90).
+ * OfficeScene — cena principal do jogo (#88 → #91).
  *
- * Carrega office-map.json (34×35 tiles, 544×560px) e renderiza as camadas:
+ * Carrega office-map.json (34×35 tiles, 544×560px) e renderiza:
  *   floor      — base do escritório (carpet por zona)
- *   walls      — paredes, janelas e portas
- *   furniture  — mesas, cadeiras e plantas
+ *   walls      — paredes + colisão (GIDs 2-3, 7-8)
+ *   furniture  — mesas/cadeiras + colisão (GIDs 4-5)
  *
- * Lê zone-markers (objectgroup) para expor getZoneCenterWorld() (#92).
+ * Expõe getZoneBounds() e getZoneCenterWorld() para AgentSprite (#92).
  *
  * Fluxo: PreloadScene → OfficeScene
  */
@@ -24,6 +24,8 @@ export type ZoneId =
 
 export class OfficeScene extends Phaser.Scene {
   private zoneRects = new Map<string, Phaser.Geom.Rectangle>()
+  wallsLayer: Phaser.Tilemaps.TilemapLayer | null = null
+  furnitureLayer: Phaser.Tilemaps.TilemapLayer | null = null
 
   constructor() {
     super({ key: 'OfficeScene' })
@@ -31,13 +33,18 @@ export class OfficeScene extends Phaser.Scene {
 
   create() {
     const map = this.make.tilemap({ key: 'office-map' })
-
     const tileset = map.addTilesetImage('tileset-placeholder', 'tile-placeholder')
 
     if (tileset) {
       map.createLayer('floor', tileset, 0, 0)
-      map.createLayer('walls', tileset, 0, 0)
-      map.createLayer('furniture', tileset, 0, 0)
+
+      this.wallsLayer = map.createLayer('walls', tileset, 0, 0)
+      // GID 3 = wall (sólido). Portas (GID 7) e janelas (GID 8) são passáveis.
+      this.wallsLayer?.setCollisionBetween(3, 3)
+
+      this.furnitureLayer = map.createLayer('furniture', tileset, 0, 0)
+      // GID 4 = desk, 5 = chair — colisão. Planta (GID 6) é decorativa.
+      this.furnitureLayer?.setCollisionBetween(4, 5)
     }
 
     this.parseZoneMarkers(map)
@@ -46,7 +53,12 @@ export class OfficeScene extends Phaser.Scene {
     EventBus.emit('scene-ready', this)
   }
 
-  /** Retorna o centro em pixels de uma zona pelo seu zoneId. */
+  /** Retorna os bounds em pixels de uma zona. */
+  getZoneBounds(zoneId: string): Phaser.Geom.Rectangle | null {
+    return this.zoneRects.get(zoneId) ?? null
+  }
+
+  /** Retorna o centro em pixels de uma zona. */
   getZoneCenterWorld(zoneId: string): { x: number; y: number } | null {
     const rect = this.zoneRects.get(zoneId)
     if (!rect) return null
@@ -64,24 +76,18 @@ export class OfficeScene extends Phaser.Scene {
       if (!zoneIdProp) continue
 
       const zoneId = zoneIdProp.value as string
-      const rect = new Phaser.Geom.Rectangle(
-        obj.x ?? 0,
-        obj.y ?? 0,
-        obj.width ?? 0,
-        obj.height ?? 0,
+      this.zoneRects.set(
+        zoneId,
+        new Phaser.Geom.Rectangle(obj.x ?? 0, obj.y ?? 0, obj.width ?? 0, obj.height ?? 0),
       )
-      this.zoneRects.set(zoneId, rect)
     }
   }
 
   private setupCamera(map: Phaser.Tilemaps.Tilemap) {
     const cam = this.cameras.main
     cam.setBounds(0, 0, map.widthInPixels, map.heightInPixels)
-
-    // Centraliza o mapa no viewport inicial
     cam.centerOn(map.widthInPixels / 2, map.heightInPixels / 2)
 
-    // Re-centraliza ao redimensionar a janela
     this.scale.on(Phaser.Scale.Events.RESIZE, () => {
       cam.centerOn(map.widthInPixels / 2, map.heightInPixels / 2)
     })


### PR DESCRIPTION
## Resumo

Completa a integração do tilemap no Phaser com colisão e API de zonas (#91).

## Mudanças

**`OfficeScene`**
- `wallsLayer.setCollisionBetween(3, 3)` — tile parede (GID 3) é sólido
- `furnitureLayer.setCollisionBetween(4, 5)` — desk e chair colidem; planta (GID 6) é decorativa
- `wallsLayer` e `furnitureLayer` expostos como campos públicos para sprites usarem em `#92`
- `getZoneBounds(zoneId)` retorna o `Phaser.Geom.Rectangle` completo da zona

**`PhaserGame`**
- Arcade Physics ativado (`gravity: { x:0, y:0 }`, `debug: false`)

**`office-layout.ts`**
- Interface `Zone` ganhou `worldX`, `worldY`, `worldW`, `worldH` (pixels do tilemap)
- Todos os 6 zones populados com coordenadas reais do `office-map.json`

Closes #91

## Test plan

- [ ] `pnpm typecheck` sem erros
- [ ] 176 testes passando
- [ ] `getZoneBounds('dev-zone')` retorna `Rectangle { x:16, y:32, w:160, h:192 }`
- [ ] Arcade physics ativa (sem erros no console)