### PR TITLE
feat(sprite): AgentSprite com walk/idle e tint por agente

### DIFF
--- a/src/game/objects/AgentSprite.ts
+++ b/src/game/objects/AgentSprite.ts
@@ -1,0 +1,122 @@
+import Phaser from 'phaser'
+
+/**
+ * AgentSprite — personagem animado no tilemap (#92).
+ *
+ * Usa o spritesheet `agent-sprite` (48×64px, 16×16px/frame):
+ *   Row 0 (down):  frames 0-2  → idle, walk-A, walk-B
+ *   Row 1 (left):  frames 3-5
+ *   Row 2 (right): frames 6-8
+ *   Row 3 (up):    frames 9-11
+ *
+ * Tint por agente: violet (#8b5cf6), emerald (#10b981), amber (#f59e0b).
+ */
+
+/** Direções suportadas para walk cycle. */
+type Direction = 'down' | 'left' | 'right' | 'up'
+
+const ANIM_FRAME_RATE = 8
+
+/** Registra animações na cena (chamado uma vez por cena). */
+export function registerAgentAnimations(scene: Phaser.Scene): void {
+  const key = 'agent-sprite'
+  if (scene.anims.exists('idle-down')) return // já registradas
+
+  scene.anims.create({
+    key: 'idle-down',
+    frames: scene.anims.generateFrameNumbers(key, { frames: [0] }),
+    frameRate: 1,
+    repeat: -1,
+  })
+
+  const directions: Array<[string, number]> = [
+    ['down', 0],
+    ['left', 3],
+    ['right', 6],
+    ['up', 9],
+  ]
+
+  for (const [dir, start] of directions) {
+    scene.anims.create({
+      key: `walk-${dir}`,
+      frames: scene.anims.generateFrameNumbers(key, { frames: [start, start + 1, start + 2] }),
+      frameRate: ANIM_FRAME_RATE,
+      repeat: -1,
+    })
+  }
+}
+
+export class AgentSprite extends Phaser.GameObjects.Sprite {
+  readonly agentId: string
+  private currentDirection: Direction = 'down'
+  private activeTween: Phaser.Tweens.Tween | null = null
+
+  constructor(
+    scene: Phaser.Scene,
+    x: number,
+    y: number,
+    agentId: string,
+    tintColor: number,
+  ) {
+    super(scene, x, y, 'agent-sprite', 0)
+    this.agentId = agentId
+    this.setTint(tintColor)
+    this.setDepth(10)
+    scene.add.existing(this)
+    this.play('idle-down')
+  }
+
+  /**
+   * Move o sprite suavemente para (x, y) com tween.
+   * Determina a direção pelo delta e troca para walk cycle.
+   */
+  moveTo(x: number, y: number, onComplete?: () => void): void {
+    const dx = x - this.x
+    const dy = y - this.y
+
+    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) {
+      onComplete?.()
+      return
+    }
+
+    this.currentDirection = this.directionFrom(dx, dy)
+    this.play(`walk-${this.currentDirection}`, true)
+
+    this.activeTween?.stop()
+
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    const duration = Math.min(Math.max(dist * 10, 300), 2000)
+
+    this.activeTween = this.scene.tweens.add({
+      targets: this,
+      x,
+      y,
+      duration,
+      ease: 'Linear',
+      onComplete: () => {
+        this.activeTween = null
+        this.play('idle-down', true)
+        onComplete?.()
+      },
+    })
+  }
+
+  /**
+   * Troca estado visual baseado no status do agente.
+   * idle/offline/blocked → idle-down; outros → walk no loop atual.
+   */
+  setStatus(status: string): void {
+    if (status === 'idle' || status === 'offline' || status === 'blocked') {
+      if (!this.activeTween) this.play('idle-down', true)
+    } else {
+      if (!this.activeTween) this.play(`walk-${this.currentDirection}`, true)
+    }
+  }
+
+  private directionFrom(dx: number, dy: number): Direction {
+    if (Math.abs(dx) >= Math.abs(dy)) {
+      return dx > 0 ? 'right' : 'left'
+    }
+    return dy > 0 ? 'down' : 'up'
+  }
+}

--- a/src/game/scenes/OfficeScene.ts
+++ b/src/game/scenes/OfficeScene.ts
@@ -28,6 +28,7 @@ export type ZoneId =
 export class OfficeScene extends Phaser.Scene {
   private zoneRects = new Map<string, Phaser.Geom.Rectangle>()
   private agentSprites = new Map<string, AgentSprite>()
+  private readonly onAgentsUpdated = (agents: AgentOfficeData[]) => this.syncAgents(agents)
   wallsLayer: Phaser.Tilemaps.TilemapLayer | null = null
   furnitureLayer: Phaser.Tilemaps.TilemapLayer | null = null
 
@@ -53,9 +54,9 @@ export class OfficeScene extends Phaser.Scene {
     this.setupCamera(map)
     registerAgentAnimations(this)
 
-    EventBus.on('agents-updated', this.syncAgents, this)
+    EventBus.on('agents-updated', this.onAgentsUpdated)
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
-      EventBus.off('agents-updated', this.syncAgents, this)
+      EventBus.off('agents-updated', this.onAgentsUpdated)
     })
 
     EventBus.emit('scene-ready', this)

--- a/src/game/scenes/OfficeScene.ts
+++ b/src/game/scenes/OfficeScene.ts
@@ -1,15 +1,18 @@
 import Phaser from 'phaser'
 import { EventBus } from '../EventBus'
+import { AgentSprite, registerAgentAnimations } from '../objects/AgentSprite'
+import type { AgentOfficeData } from '../../hooks/useOfficeState'
+import { getAgentColor } from '../../constants/agent'
 
 /**
- * OfficeScene — cena principal do jogo (#88 → #91).
+ * OfficeScene — cena principal do jogo (#88 → #92).
  *
  * Carrega office-map.json (34×35 tiles, 544×560px) e renderiza:
  *   floor      — base do escritório (carpet por zona)
- *   walls      — paredes + colisão (GIDs 2-3, 7-8)
+ *   walls      — paredes + colisão (GIDs 3)
  *   furniture  — mesas/cadeiras + colisão (GIDs 4-5)
  *
- * Expõe getZoneBounds() e getZoneCenterWorld() para AgentSprite (#92).
+ * Ouve `agents-updated` do EventBus e instancia/atualiza AgentSprites.
  *
  * Fluxo: PreloadScene → OfficeScene
  */
@@ -24,6 +27,7 @@ export type ZoneId =
 
 export class OfficeScene extends Phaser.Scene {
   private zoneRects = new Map<string, Phaser.Geom.Rectangle>()
+  private agentSprites = new Map<string, AgentSprite>()
   wallsLayer: Phaser.Tilemaps.TilemapLayer | null = null
   furnitureLayer: Phaser.Tilemaps.TilemapLayer | null = null
 
@@ -39,18 +43,51 @@ export class OfficeScene extends Phaser.Scene {
       map.createLayer('floor', tileset, 0, 0)
 
       this.wallsLayer = map.createLayer('walls', tileset, 0, 0)
-      // GID 3 = wall (sólido). Portas (GID 7) e janelas (GID 8) são passáveis.
       this.wallsLayer?.setCollisionBetween(3, 3)
 
       this.furnitureLayer = map.createLayer('furniture', tileset, 0, 0)
-      // GID 4 = desk, 5 = chair — colisão. Planta (GID 6) é decorativa.
       this.furnitureLayer?.setCollisionBetween(4, 5)
     }
 
     this.parseZoneMarkers(map)
     this.setupCamera(map)
+    registerAgentAnimations(this)
+
+    EventBus.on('agents-updated', this.syncAgents, this)
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      EventBus.off('agents-updated', this.syncAgents, this)
+    })
 
     EventBus.emit('scene-ready', this)
+  }
+
+  /** Sincroniza AgentSprites com a lista de agentes do React. */
+  private syncAgents(agents: AgentOfficeData[]): void {
+    const seen = new Set<string>()
+
+    for (const agent of agents) {
+      seen.add(agent.id)
+      const center = this.getZoneCenterWorld(agent.zoneId) ?? { x: 272, y: 280 }
+
+      let sprite = this.agentSprites.get(agent.id)
+      if (!sprite) {
+        const hex = parseInt(getAgentColor(agent.id).replace('#', ''), 16)
+        sprite = new AgentSprite(this, center.x, center.y, agent.id, hex)
+        this.agentSprites.set(agent.id, sprite)
+      } else {
+        sprite.moveTo(center.x, center.y)
+      }
+
+      sprite.setStatus(agent.status)
+    }
+
+    // Remove sprites de agentes que saíram
+    for (const [id, sprite] of this.agentSprites) {
+      if (!seen.has(id)) {
+        sprite.destroy()
+        this.agentSprites.delete(id)
+      }
+    }
   }
 
   /** Retorna os bounds em pixels de uma zona. */


### PR DESCRIPTION
## Resumo

Substitui os círculos CSS por sprites Phaser animados com walk cycle e tint por agente (#92).

## `AgentSprite` (`src/game/objects/AgentSprite.ts`)

| Feature | Detalhe |
|---------|---------|
| Animações | `idle-down`, `walk-down/left/right/up` (8fps, 3 frames cada) |
| Tint | `rx-architect` → violet, `rx-backend` → emerald, `rx-orchestrator` → amber |
| `moveTo(x, y)` | Tween linear, duração proporcional à distância (300–2000ms) |
| `setStatus(s)` | `idle/offline/blocked` → `idle-down`; outros → walk atual |

## `OfficeScene` atualizado

- Registra animações via `registerAgentAnimations()` no `create()`
- Ouve `agents-updated` do `EventBus` → `syncAgents()`
- `syncAgents`: cria sprite novo / move existente / destroi removidos
- Cleanup correto no `SHUTDOWN` da cena

Closes #92

## Test plan

- [ ] `pnpm typecheck` sem erros
- [ ] 176 testes passando
- [ ] Sprites aparecem no mapa com tint por agente
- [ ] `moveTo` anima suavemente entre zonas
- [ ] `idle-down` toca quando agente está parado