### PR TITLE
feat(bridge): usePhaserBridge sincroniza React → AgentSprites

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,13 +13,16 @@ import { AgentDetailPanel } from './components/AgentDetailPanel'
 import { getSocket } from './services/socket'
 import { PhaserGame } from './game/PhaserGame'
 import type { PhaserGameRef } from './game/PhaserGame'
+import { usePhaserBridge } from './hooks/usePhaserBridge'
 
 export function App() {
   const { status } = useSocket()
   const { agents, users, isLoading, error, setZoneOverride, clearZoneOverride, retry } =
     useOfficeState()
+
+  // Bridge React → Phaser: emite agents-updated via EventBus (#93)
+  usePhaserBridge(agents)
   const canvasRef = useRef<HTMLDivElement>(null)
-  // Ref exposta para uso futuro na bridge EventBus (#93)
   const phaserRef = useRef<PhaserGameRef>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
 

--- a/src/hooks/usePhaserBridge.test.ts
+++ b/src/hooks/usePhaserBridge.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// vi.hoisted garante que mockBus existe antes do hoist de vi.mock
+const { mockBus, listeners } = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+  const mockBus = {
+    emit: vi.fn((event: string, ...args: unknown[]) => {
+      listeners.get(event)?.forEach((fn) => fn(...args))
+    }),
+    on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(fn)
+    }),
+    off: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(fn)
+    }),
+    once: vi.fn(),
+  }
+  return { mockBus, listeners }
+})
+
+vi.mock('../game/EventBus', () => ({ EventBus: mockBus }))
+
+import { usePhaserBridge } from './usePhaserBridge'
+import type { AgentOfficeData } from './useOfficeState'
+
+const makeAgent = (id: string, status = 'working', zoneId = 'dev-zone'): AgentOfficeData => ({
+  id,
+  name: id,
+  role: 'agent',
+  status,
+  currentTask: '',
+  zoneId,
+  position: { x: 50, y: 50 },
+  color: '#8b5cf6',
+  speechText: null,
+  isManualOverride: false,
+})
+
+describe('usePhaserBridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    listeners.clear()
+  })
+
+  it('emite agents-updated ao montar', () => {
+    const agents = [makeAgent('rx-architect')]
+    renderHook(() => usePhaserBridge(agents))
+    expect(mockBus.emit).toHaveBeenCalledWith('agents-updated', agents)
+  })
+
+  it('re-emite agents-updated ao receber scene-ready', () => {
+    const agents = [makeAgent('rx-architect')]
+    renderHook(() => usePhaserBridge(agents))
+
+    mockBus.emit.mockClear()
+    act(() => {
+      // Simula Phaser emitindo scene-ready
+      mockBus.emit('scene-ready', {} as never)
+    })
+
+    expect(mockBus.emit).toHaveBeenCalledWith('agents-updated', agents)
+  })
+
+  it('emite novamente quando agents muda', () => {
+    const agents1 = [makeAgent('rx-architect')]
+    const agents2 = [makeAgent('rx-architect', 'idle', 'coffee-corner')]
+
+    const { rerender } = renderHook(({ agents }) => usePhaserBridge(agents), {
+      initialProps: { agents: agents1 },
+    })
+
+    mockBus.emit.mockClear()
+    rerender({ agents: agents2 })
+
+    expect(mockBus.emit).toHaveBeenCalledWith('agents-updated', agents2)
+  })
+
+  it('remove listener de scene-ready ao desmontar', () => {
+    const { unmount } = renderHook(() => usePhaserBridge([]))
+    unmount()
+    expect(mockBus.off).toHaveBeenCalledWith('scene-ready', expect.any(Function))
+  })
+})

--- a/src/hooks/usePhaserBridge.ts
+++ b/src/hooks/usePhaserBridge.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+import { EventBus } from '../game/EventBus'
+import type { AgentOfficeData } from './useOfficeState'
+
+/**
+ * usePhaserBridge — sincroniza estado React → Phaser via EventBus (#93).
+ *
+ * Emite `agents-updated` sempre que `agents` muda.
+ * Quando a cena ainda não estava pronta, re-emite ao receber `scene-ready`
+ * para garantir que os sprites são criados mesmo se os dados chegarem antes
+ * do Phaser terminar de inicializar.
+ *
+ * Cleanup: remove todos os listeners ao desmontar.
+ */
+export function usePhaserBridge(agents: AgentOfficeData[]): void {
+  const agentsRef = useRef(agents)
+  agentsRef.current = agents
+
+  // Emite quando agents mudam
+  useEffect(() => {
+    EventBus.emit('agents-updated', agents)
+  }, [agents])
+
+  // Re-emite no scene-ready (Phaser pode inicializar depois do primeiro render)
+  useEffect(() => {
+    const onSceneReady = () => {
+      EventBus.emit('agents-updated', agentsRef.current)
+    }
+    EventBus.on('scene-ready', onSceneReady)
+    return () => {
+      EventBus.off('scene-ready', onSceneReady)
+    }
+  }, [])
+}


### PR DESCRIPTION
## Resumo

Implementa a bridge React → Phaser via EventBus (#93).

## `usePhaserBridge(agents)`

| Comportamento | Detalhe |
|---------------|---------|
| Mount | Emite `agents-updated` imediatamente com agents atuais |
| `agents` muda | Re-emite `agents-updated` |
| `scene-ready` recebido | Re-emite `agents-updated` (Phaser pode inicializar depois) |
| Unmount | Remove listener de `scene-ready` |

## Integração em `App.tsx`

```ts
usePhaserBridge(agents)  // logo após useOfficeState()
```

## Testes

- 4 testes cobrindo mount, re-emit no scene-ready, mudança de agents e cleanup
- `vi.hoisted()` para mock do EventBus sem carregar Phaser em JSDOM

Closes #93

## Test plan

- [ ] `pnpm typecheck` sem erros
- [ ] 180 testes passando
- [ ] Sprites Phaser se movem ao mudar `MOCK_AGENTS` em `mock-agents.ts`