### PR TITLE
refactor(agents): retry automático e timeout no serviço (#116)

### DIFF
--- a/src/hooks/useOfficeState.test.ts
+++ b/src/hooks/useOfficeState.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
+import { Ok, Err } from '@roxdavirox/fp-core/result'
 import type { RawAgent } from './useOfficeState'
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -20,6 +21,12 @@ vi.mock('../services/socket', () => ({
   socket: mockSocket,
   connectSocket: vi.fn(),
 }))
+
+vi.mock('../services/agents', () => ({
+  fetchAgents: vi.fn(),
+}))
+
+import { fetchAgents } from '../services/agents'
 
 const mockAgents: RawAgent[] = [
   {
@@ -61,17 +68,10 @@ beforeEach(() => {
   mockSocket.on.mockClear()
   mockSocket.off.mockClear()
 
-  vi.stubGlobal(
-    'fetch',
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockAgents),
-    })
-  )
+  vi.mocked(fetchAgents).mockResolvedValue(Ok(mockAgents))
 })
 
 afterEach(() => {
-  vi.unstubAllGlobals()
   vi.useRealTimers()
 })
 
@@ -153,7 +153,7 @@ describe('useOfficeState — initial load', () => {
 
 describe('useOfficeState — API error', () => {
   it('sets error and exits loading when fetch fails', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
+    vi.mocked(fetchAgents).mockResolvedValue(Err('HTTP 500'))
 
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -347,19 +347,13 @@ describe('useOfficeState — zone override', () => {
 
 describe('useOfficeState — retry', () => {
   it('retry re-triggers the fetch and clears the error', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+    vi.mocked(fetchAgents).mockResolvedValue(Err('HTTP 503'))
 
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.error).toMatch(/503/))
 
-    // Switch mock to succeed on second call
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockAgents),
-      })
-    )
+    // Switch mock to succeed on next call
+    vi.mocked(fetchAgents).mockResolvedValue(Ok(mockAgents))
 
     act(() => {
       result.current.retry()
@@ -371,20 +365,17 @@ describe('useOfficeState — retry', () => {
   })
 
   it('retry sets isLoading=true before fetch resolves', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+    vi.mocked(fetchAgents).mockResolvedValue(Err('HTTP 503'))
 
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.error).toMatch(/503/))
 
     // Use a pending promise to freeze the fetch mid-flight
-    let resolveFetch!: (v: unknown) => void
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockReturnValue(
-        new Promise((res) => {
-          resolveFetch = res
-        })
-      )
+    let resolveAgents!: (v: ReturnType<typeof Ok<typeof mockAgents>>) => void
+    vi.mocked(fetchAgents).mockReturnValue(
+      new Promise((res) => {
+        resolveAgents = res
+      })
     )
 
     act(() => {
@@ -394,7 +385,7 @@ describe('useOfficeState — retry', () => {
     expect(result.current.isLoading).toBe(true)
 
     // Resolve to avoid lingering promise
-    resolveFetch({ ok: true, json: () => Promise.resolve(mockAgents) })
+    resolveAgents(Ok(mockAgents))
     await waitFor(() => expect(result.current.isLoading).toBe(false))
   })
 })

--- a/src/hooks/useOfficeState.test.ts
+++ b/src/hooks/useOfficeState.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
-import { Ok, Err } from '@roxdavirox/fp-core/result'
+import { Ok, Err, type Result } from '@roxdavirox/fp-core/result'
 import type { RawAgent } from './useOfficeState'
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -371,10 +371,10 @@ describe('useOfficeState — retry', () => {
     await waitFor(() => expect(result.current.error).toMatch(/503/))
 
     // Use a pending promise to freeze the fetch mid-flight
-    let resolveAgents!: (v: ReturnType<typeof Ok<typeof mockAgents>>) => void
+    let resolveAgents!: (v: Result<RawAgent[], string>) => void
     vi.mocked(fetchAgents).mockReturnValue(
-      new Promise((res) => {
-        resolveAgents = res
+      new Promise<Result<RawAgent[], string>>((res) => {
+        resolveAgents = res as typeof resolveAgents
       })
     )
 

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -228,7 +228,8 @@ export interface UseOfficeStateReturn extends Omit<OfficeState, 'overrides'> {
 
 export function useOfficeState(): UseOfficeStateReturn {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
-  const [retryCount, setRetryCount] = useState(0)
+  // retryKey é incrementado pelo botão "Retry" da UI para re-disparar o fetch
+  const [retryKey, setRetryKey] = useState(0)
 
   // Keep refs of speech bubble timers per agent for cleanup
   const speechTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
@@ -251,11 +252,13 @@ export function useOfficeState(): UseOfficeStateReturn {
     dispatch({ type: 'AGENT_ZONE_CLEAR_OVERRIDE', agentId })
   }, [])
 
+  // retry manual — usado pelo botão da UI; fetchAgents já faz 3 tentativas automáticas
   const retry = useCallback(() => {
-    setRetryCount((c) => c + 1)
+    setRetryKey((k) => k + 1)
   }, [])
 
   // ── Initial load via REST (or mock) ─────────────────────────────────────
+  // fetchAgents já faz retry automático (3×, backoff 2×) e timeout de 8s (#116)
   useEffect(() => {
     if (IS_MOCK_MODE) {
       dispatch({ type: 'AGENTS_LOADED', agents: MOCK_AGENTS })
@@ -278,7 +281,7 @@ export function useOfficeState(): UseOfficeStateReturn {
     return () => {
       controller.abort()
     }
-  }, [retryCount])
+  }, [retryKey])
 
   // ── Socket events ───────────────────────────────────────────────────────
   useEffect(() => {

--- a/src/services/agents.ts
+++ b/src/services/agents.ts
@@ -46,7 +46,7 @@ export async function fetchAgents(signal: AbortSignal): Promise<Result<RawAgent[
 
   const result = await retry(RETRY_ATTEMPTS, RETRY_DELAY_MS, RETRY_BACKOFF)(attempt)
 
-  if (result.ok) return Ok(result.value)
+  if (result.ok) return Ok(result.value as RawAgent[])
 
   // AbortError = cancelamento intencional — propaga para caller ignorar
   if (result.error instanceof DOMException && result.error.name === 'AbortError') {

--- a/src/services/agents.ts
+++ b/src/services/agents.ts
@@ -1,25 +1,33 @@
 import { Ok, Err, type Result } from '@roxdavirox/fp-core/result'
-import { pipeAsync } from '@roxdavirox/fp-core/async'
+import { pipeAsync, retry, timeout } from '@roxdavirox/fp-core/async'
 import type { RawAgent } from '../hooks/useOfficeState'
 
 const AGENTS_URL = `${import.meta.env.VITE_MAGO_BACKEND_URL ?? 'http://localhost:3002'}/api/dashboard/agents`
 
-/**
- * Parseia a Response HTTP em Result<RawAgent[], string>.
- * Erros HTTP (4xx/5xx) viram Err; JSON inválido propaga exceção
- * para o catch externo.
- */
-const parseResponse = pipeAsync(
-  async (res: Response): Promise<Result<RawAgent[], string>> =>
-    res.ok ? Ok(await (res.json() as Promise<RawAgent[]>)) : Err(`HTTP ${res.status}`),
-)
+/** Configuração de retry: 3 tentativas, 1s inicial, backoff 2× */
+const RETRY_ATTEMPTS = 3
+const RETRY_DELAY_MS = 1000
+const RETRY_BACKOFF = 2
+
+/** Timeout total por tentativa: 8s */
+const FETCH_TIMEOUT_MS = 8000
 
 /**
- * Busca agentes do backend MAGO e retorna Result<RawAgent[], string>.
+ * Parseia a Response HTTP → RawAgent[] (lança em caso de erro HTTP).
+ * Erros de parsing JSON propagam para o retry fazer nova tentativa.
+ */
+const parseResponse = pipeAsync(async (res: Response): Promise<RawAgent[]> => {
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json() as Promise<RawAgent[]>
+})
+
+/**
+ * Busca agentes do backend MAGO com retry automático e timeout (#116).
  *
- * - Usa AbortSignal para suportar cancelamento limpo (#113)
- * - AbortError é re-lançado para o caller tratar (não é um Err)
- * - Erros de rede viram Err<string>
+ * - 3 tentativas com backoff exponencial (1s → 2s → 4s)
+ * - Timeout de 8s por chamada
+ * - AbortError cancela imediatamente (não faz retry)
+ * - Retorna Result<RawAgent[], string> para o caller fazer dispatch
  *
  * @example
  * const controller = new AbortController()
@@ -28,12 +36,21 @@ const parseResponse = pipeAsync(
  * else dispatch({ type: 'FETCH_ERROR', error: result.error })
  */
 export async function fetchAgents(signal: AbortSignal): Promise<Result<RawAgent[], string>> {
-  try {
-    const res = await fetch(AGENTS_URL, { signal })
-    return parseResponse(res)
-  } catch (err) {
-    // AbortError = cancelamento intencional — propaga para o caller ignorar
-    if (err instanceof DOMException && err.name === 'AbortError') throw err
-    return Err(err instanceof Error ? err.message : String(err))
+  const attempt = () =>
+    timeout(FETCH_TIMEOUT_MS)(
+      fetch(AGENTS_URL, { signal }).then((res) => parseResponse(res)),
+    )
+
+  // AbortError deve cancelar sem retry — verificamos antes de tentar
+  if (signal.aborted) return Err('Aborted')
+
+  const result = await retry(RETRY_ATTEMPTS, RETRY_DELAY_MS, RETRY_BACKOFF)(attempt)
+
+  if (result.ok) return Ok(result.value)
+
+  // AbortError = cancelamento intencional — propaga para caller ignorar
+  if (result.error instanceof DOMException && result.error.name === 'AbortError') {
+    throw result.error
   }
+  return Err(result.error.message)
 }


### PR DESCRIPTION
## Summary

- Extrai lógica de fetch para `src/services/agents.ts` com `retry(3, 1s, 2×)` e `timeout(8s)` via `@roxdavirox/fp-core`
- `useOfficeState` usa `AbortController` no lugar de flag `cancelled`
- Renomeia `retryCount` → `retryKey` com comentário explicativo
- Testes do hook mockam `fetchAgents` diretamente — isolados do comportamento real de retry

## Test plan

- [x] `pnpm test` — 184 testes passando
- [x] `pnpm typecheck` — sem erros
- [x] `pnpm lint` — sem erros

Closes #116