### PR TITLE
refactor(option): null checks → Option<T> em AgentOfficeData (#114)

### DIFF
--- a/src/components/AgentAvatar.test.tsx
+++ b/src/components/AgentAvatar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
+import { None, Some } from '@roxdavirox/fp-core/option'
 import { AgentAvatar } from './AgentAvatar'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
 
@@ -53,7 +54,7 @@ const mockAgent: AgentOfficeData = {
   zoneId: 'coffee-corner',
   position: { x: 30, y: 50 },
   color: '#8b5cf6',
-  speechText: null,
+  speechText: None,
   isManualOverride: false,
 }
 
@@ -86,13 +87,13 @@ describe('AgentAvatar', () => {
     expect(onClick).toHaveBeenCalledWith(mockAgent)
   })
 
-  it('does not render SpeechBubble when speechText is null', () => {
+  it('does not render SpeechBubble when speechText is None', () => {
     render(<AgentAvatar agent={mockAgent} />)
     expect(screen.queryByText(/waiting/i)).toBeNull()
   })
 
-  it('renders SpeechBubble when speechText is set', () => {
-    render(<AgentAvatar agent={{ ...mockAgent, speechText: 'Analyzing code' }} />)
+  it('renders SpeechBubble when speechText is Some', () => {
+    render(<AgentAvatar agent={{ ...mockAgent, speechText: Some('Analyzing code') }} />)
     expect(screen.getByText('Analyzing code')).toBeTruthy()
   })
 

--- a/src/components/AgentDetailPanel.test.tsx
+++ b/src/components/AgentDetailPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { None } from '@roxdavirox/fp-core/option'
 import { AgentDetailPanel } from './AgentDetailPanel'
 import type { AgentOfficeData } from '../hooks/useOfficeState'
 
@@ -53,7 +54,7 @@ const mockAgent: AgentOfficeData = {
   zoneId: 'dev-zone',
   position: { x: 50, y: 50 },
   color: '#8b5cf6',
-  speechText: null,
+  speechText: None,
   isManualOverride: false,
 }
 

--- a/src/components/SpeechBubble.test.tsx
+++ b/src/components/SpeechBubble.test.tsx
@@ -1,33 +1,34 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { None, Some } from '@roxdavirox/fp-core/option'
 import { SpeechBubble } from './SpeechBubble'
 
 describe('SpeechBubble', () => {
-  it('renders nothing when text is null', () => {
-    const { container } = render(<SpeechBubble text={null} color="#8b5cf6" />)
+  it('renders nothing when text is None', () => {
+    const { container } = render(<SpeechBubble text={None} color="#8b5cf6" />)
     expect(container.firstChild).toBeNull()
   })
 
   it('renders the text when provided', () => {
-    render(<SpeechBubble text="Implementing feature" color="#8b5cf6" />)
+    render(<SpeechBubble text={Some('Implementing feature')} color="#8b5cf6" />)
     expect(screen.getByText('Implementing feature')).toBeTruthy()
   })
 
   it('truncates text longer than 40 chars with ellipsis', () => {
     const longText = 'A'.repeat(50)
-    render(<SpeechBubble text={longText} color="#8b5cf6" />)
+    render(<SpeechBubble text={Some(longText)} color="#8b5cf6" />)
     const el = screen.getByText(`${'A'.repeat(40)}…`)
     expect(el).toBeTruthy()
   })
 
   it('does not truncate text with exactly 40 chars', () => {
     const text = 'A'.repeat(40)
-    render(<SpeechBubble text={text} color="#8b5cf6" />)
+    render(<SpeechBubble text={Some(text)} color="#8b5cf6" />)
     expect(screen.getByText(text)).toBeTruthy()
   })
 
   it('renders the downward-pointing arrow', () => {
-    render(<SpeechBubble text="test" color="#8b5cf6" />)
+    render(<SpeechBubble text={Some('test')} color="#8b5cf6" />)
     expect(screen.getByTestId('speech-arrow')).toBeTruthy()
   })
 })

--- a/src/components/SpeechBubble.tsx
+++ b/src/components/SpeechBubble.tsx
@@ -1,8 +1,9 @@
 import { memo } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
+import { type Option, isSome } from '@roxdavirox/fp-core/option'
 
 interface SpeechBubbleProps {
-  text: string | null
+  text: Option<string>
   color: string
 }
 
@@ -53,20 +54,24 @@ const variants = {
 }
 
 export const SpeechBubble = memo(function SpeechBubble({ text, color }: SpeechBubbleProps) {
-  const truncated = text && text.length > MAX_LENGTH ? `${text.slice(0, MAX_LENGTH)}…` : text
+  const content = isSome(text)
+    ? text.value.length > MAX_LENGTH
+      ? `${text.value.slice(0, MAX_LENGTH)}…`
+      : text.value
+    : null
 
   return (
     <AnimatePresence>
-      {truncated && (
+      {content && (
         <motion.div
-          key={truncated}
+          key={content}
           variants={variants}
           initial="hidden"
           animate="visible"
           exit="exit"
           style={{ ...STYLES.bubble, border: `1px solid ${color}80` }}
         >
-          {truncated}
+          {content}
           {/* Downward-pointing arrow */}
           <span
             data-testid="speech-arrow"

--- a/src/game/scenes/OfficeScene.ts
+++ b/src/game/scenes/OfficeScene.ts
@@ -3,6 +3,7 @@ import { EventBus } from '../EventBus'
 import { AgentSprite, registerAgentAnimations } from '../objects/AgentSprite'
 import type { AgentOfficeData } from '../../hooks/useOfficeState'
 import { getAgentColor } from '../../constants/agent'
+import { type Option, Some, None, isSome } from '@roxdavirox/fp-core/option'
 
 /**
  * OfficeScene — cena principal do jogo (#88 → #92).
@@ -68,7 +69,8 @@ export class OfficeScene extends Phaser.Scene {
 
     for (const agent of agents) {
       seen.add(agent.id)
-      const center = this.getZoneCenterWorld(agent.zoneId) ?? { x: 272, y: 280 }
+      const centerOpt = this.getZoneCenterWorld(agent.zoneId)
+      const center = isSome(centerOpt) ? centerOpt.value : { x: 272, y: 280 }
 
       let sprite = this.agentSprites.get(agent.id)
       if (!sprite) {
@@ -97,10 +99,10 @@ export class OfficeScene extends Phaser.Scene {
   }
 
   /** Retorna o centro em pixels de uma zona. */
-  getZoneCenterWorld(zoneId: string): { x: number; y: number } | null {
+  getZoneCenterWorld(zoneId: string): Option<{ x: number; y: number }> {
     const rect = this.zoneRects.get(zoneId)
-    if (!rect) return null
-    return { x: rect.centerX, y: rect.centerY }
+    if (!rect) return None
+    return Some({ x: rect.centerX, y: rect.centerY })
   }
 
   private parseZoneMarkers(map: Phaser.Tilemaps.Tilemap) {

--- a/src/hooks/useOfficeState.test.ts
+++ b/src/hooks/useOfficeState.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { Ok, Err, type Result } from '@roxdavirox/fp-core/result'
+import { Some, isSome, isNone } from '@roxdavirox/fp-core/option'
 import type { RawAgent } from './useOfficeState'
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -141,12 +142,12 @@ describe('useOfficeState — initial load', () => {
     expect(backend?.currentTask).toBe('implementing feature X')
   })
 
-  it('speechText starts as null', async () => {
+  it('speechText starts as None', async () => {
     const { result } = renderHook(() => useOfficeState())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     for (const agent of result.current.agents) {
-      expect(agent.speechText).toBeNull()
+      expect(isNone(agent.speechText)).toBe(true)
     }
   })
 })
@@ -188,7 +189,7 @@ describe('useOfficeState — socket events', () => {
     })
 
     const backend = result.current.agents.find((a) => a.id === 'rx-backend')
-    expect(backend?.speechText).toBe('Starting analysis')
+    expect(backend?.speechText).toEqual(Some('Starting analysis'))
   })
 
   it('bus:message without content does not change speechText', async () => {
@@ -201,7 +202,8 @@ describe('useOfficeState — socket events', () => {
     })
 
     const backend = result.current.agents.find((a) => a.id === 'rx-backend')
-    expect(backend?.speechText).toBeNull()
+    expect(backend).toBeDefined()
+    expect(isSome(backend!.speechText)).toBe(false)
   })
 
   it('clears speechText after 5 seconds', async () => {
@@ -216,13 +218,15 @@ describe('useOfficeState — socket events', () => {
       handler?.({ from: 'rx-backend', payload: { content: 'Working...' } })
     })
 
-    expect(result.current.agents.find((a) => a.id === 'rx-backend')?.speechText).toBe('Working...')
+    expect(result.current.agents.find((a) => a.id === 'rx-backend')?.speechText).toEqual(Some('Working...'))
 
     act(() => {
       vi.advanceTimersByTime(5000)
     })
 
-    expect(result.current.agents.find((a) => a.id === 'rx-backend')?.speechText).toBeNull()
+    const backendAfter = result.current.agents.find((a) => a.id === 'rx-backend')
+    expect(backendAfter).toBeDefined()
+    expect(isSome(backendAfter!.speechText)).toBe(false)
   })
 
   it('adds user when office:user:joined is received', async () => {

--- a/src/hooks/useOfficeState.ts
+++ b/src/hooks/useOfficeState.ts
@@ -8,6 +8,7 @@ import type {
 } from '../services/socket'
 import { getAgentZone, getAgentPosition, getAgentColor, AGENT_COLORS } from '../data/office-layout'
 import { MOCK_AGENTS } from '../data/mock-agents'
+import { type Option, Some, None } from '@roxdavirox/fp-core/option'
 
 const IS_MOCK_MODE = import.meta.env.VITE_MOCK_MODE === 'true'
 
@@ -37,8 +38,8 @@ export interface AgentOfficeData {
   /** Absolute position as % of the canvas */
   position: { x: number; y: number }
   color: string
-  /** Current SpeechBubble text (null = hidden) */
-  speechText: string | null
+  /** Current SpeechBubble text (None = hidden) */
+  speechText: Option<string>
   /** True when position was manually overridden by drag (visual only) */
   isManualOverride: boolean
 }
@@ -94,7 +95,7 @@ function enrichAgent(raw: RawAgent): AgentOfficeData {
     zoneId,
     position,
     color: getAgentColor(raw.id),
-    speechText: null,
+    speechText: None,
     isManualOverride: false,
   }
 }
@@ -156,14 +157,14 @@ function reducer(state: OfficeState, action: Action): OfficeState {
       return {
         ...state,
         agents: state.agents.map((a) =>
-          a.id === action.agentId ? { ...a, speechText: action.text } : a
+          a.id === action.agentId ? { ...a, speechText: Some(action.text) } : a
         ),
       }
 
     case 'AGENT_SPEECH_CLEAR':
       return {
         ...state,
-        agents: state.agents.map((a) => (a.id === action.agentId ? { ...a, speechText: null } : a)),
+        agents: state.agents.map((a) => (a.id === action.agentId ? { ...a, speechText: None } : a)),
       }
 
     case 'AGENT_ZONE_OVERRIDE':

--- a/src/hooks/usePhaserBridge.test.ts
+++ b/src/hooks/usePhaserBridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
+import { None } from '@roxdavirox/fp-core/option'
 
 // vi.hoisted garante que mockBus existe antes do hoist de vi.mock
 const { mockBus, listeners } = vi.hoisted(() => {
@@ -34,7 +35,7 @@ const makeAgent = (id: string, status = 'working', zoneId = 'dev-zone'): AgentOf
   zoneId,
   position: { x: 50, y: 50 },
   color: '#8b5cf6',
-  speechText: null,
+  speechText: None,
   isManualOverride: false,
 })
 


### PR DESCRIPTION
## Summary

- `speechText: string | null` → `Option<string>` em `AgentOfficeData`
- `SpeechBubble` aceita `Option<string>`, usa `isSome` para render condicional (sem `=== null`)
- `getZoneCenterWorld` em `OfficeScene` retorna `Option<{x,y}>` — usa `isSome` no call site
- Todos os testes atualizados para `Some` / `None` / `isSome` / `isNone`

## Test plan

- [x] `pnpm test` — 184 testes passando
- [x] `pnpm typecheck` (tsc -b) — sem erros

Closes #114