### PR TITLE
feat(sprite): HumanSprite com WASD/clique e câmera seguindo

### DIFF
--- a/src/game/objects/HumanSprite.test.ts
+++ b/src/game/objects/HumanSprite.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockBus } = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+  const mockBus = {
+    emit: vi.fn((event: string, ...args: unknown[]) => {
+      listeners.get(event)?.forEach((fn) => fn(...args))
+    }),
+    on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(fn)
+    }),
+    off: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(fn)
+    }),
+  }
+  return { mockBus, listeners }
+})
+
+vi.mock('../EventBus', () => ({ EventBus: mockBus }))
+
+vi.mock('phaser', () => {
+  const MockSprite = vi.fn().mockImplementation(function (
+    this: Record<string, unknown>,
+    scene: Record<string, unknown>,
+  ) {
+    this.x = 0
+    this.y = 0
+    this.scene = scene
+    this.body = {
+      setSize: vi.fn(),
+      setOffset: vi.fn(),
+      setVelocity: vi.fn(),
+    }
+    this.anims = {
+      isPlaying: false,
+      currentAnim: null,
+    }
+  })
+  MockSprite.prototype.setTint = vi.fn()
+  MockSprite.prototype.setDepth = vi.fn()
+  MockSprite.prototype.setCollideWorldBounds = vi.fn()
+  MockSprite.prototype.play = vi.fn(function (this: Record<string, unknown>, key: string) {
+    const anims = this.anims as { currentAnim: { key: string } | null; isPlaying: boolean }
+    anims.currentAnim = { key }
+    anims.isPlaying = true
+  })
+  MockSprite.prototype.destroy = vi.fn()
+
+  return {
+    default: {
+      Physics: {
+        Arcade: {
+          Sprite: MockSprite,
+        },
+      },
+      Input: {
+        Keyboard: { KeyCodes: { W: 87, A: 65, S: 83, D: 68 } },
+      },
+    },
+  }
+})
+
+import { HumanSprite } from './HumanSprite'
+
+function createMockScene() {
+  return {
+    add: { existing: vi.fn() },
+    physics: {
+      add: {
+        existing: vi.fn(),
+        collider: vi.fn(),
+      },
+      moveTo: vi.fn(),
+    },
+    input: {
+      keyboard: {
+        createCursorKeys: vi.fn(() => ({
+          left: { isDown: false },
+          right: { isDown: false },
+          up: { isDown: false },
+          down: { isDown: false },
+        })),
+        addKey: vi.fn(() => ({ isDown: false })),
+      },
+      on: vi.fn(),
+    },
+    cameras: {
+      main: {
+        startFollow: vi.fn(),
+        getWorldPoint: vi.fn(() => ({ x: 100, y: 100 })),
+      },
+    },
+    tweens: {
+      add: vi.fn(() => ({ stop: vi.fn() })),
+      addCounter: vi.fn(() => ({ stop: vi.fn() })),
+    },
+  }
+}
+
+describe('HumanSprite', () => {
+  let scene: ReturnType<typeof createMockScene>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    scene = createMockScene()
+  })
+
+  it('cria sprite na posição informada', () => {
+    const sprite = new HumanSprite(scene as never, 100, 200)
+    expect(sprite).toBeDefined()
+    expect(scene.add.existing).toHaveBeenCalledWith(sprite)
+    expect(scene.physics.add.existing).toHaveBeenCalledWith(sprite)
+  })
+
+  it('configura tint azul e depth 20', () => {
+    const sprite = new HumanSprite(scene as never, 50, 50)
+    expect(sprite.setTint).toHaveBeenCalledWith(0x3b82f6)
+    expect(sprite.setDepth).toHaveBeenCalledWith(20)
+  })
+
+  it('configura body com hitbox reduzida', () => {
+    const sprite = new HumanSprite(scene as never, 50, 50)
+    const body = sprite.body as unknown as { setSize: ReturnType<typeof vi.fn>; setOffset: ReturnType<typeof vi.fn> }
+    expect(body.setSize).toHaveBeenCalledWith(12, 12)
+    expect(body.setOffset).toHaveBeenCalledWith(2, 4)
+  })
+
+  it('registra WASD e cursors do teclado', () => {
+    new HumanSprite(scene as never, 0, 0)
+    expect(scene.input.keyboard.createCursorKeys).toHaveBeenCalled()
+    expect(scene.input.keyboard.addKey).toHaveBeenCalledTimes(4)
+  })
+
+  it('registra listener de pointerdown para clique', () => {
+    new HumanSprite(scene as never, 0, 0)
+    expect(scene.input.on).toHaveBeenCalledWith('pointerdown', expect.any(Function))
+  })
+
+  it('setupCamera configura follow e colliders', () => {
+    const sprite = new HumanSprite(scene as never, 50, 50)
+    const camera = scene.cameras.main
+    const wallsLayer = {} as never
+    const furnitureLayer = {} as never
+
+    sprite.setupCamera(camera as never, wallsLayer, furnitureLayer)
+
+    expect(camera.startFollow).toHaveBeenCalledWith(sprite, true, 0.1, 0.1)
+    expect(scene.physics.add.collider).toHaveBeenCalledTimes(2)
+  })
+
+  it('handleInput para velocidade quando sem input', () => {
+    const sprite = new HumanSprite(scene as never, 50, 50)
+    const body = sprite.body as unknown as { setVelocity: ReturnType<typeof vi.fn> }
+
+    sprite.handleInput(1000)
+
+    expect(body.setVelocity).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('emite human-moved via EventBus com debounce', () => {
+    const sprite = new HumanSprite(scene as never, 50, 50)
+    sprite.x = 100
+    sprite.y = 200
+
+    // First emit at time=200 (> EMIT_INTERVAL_MS from lastEmitTime=0)
+    sprite.handleInput(200)
+    expect(mockBus.emit).toHaveBeenCalledWith('human-moved', 100, 200)
+
+    mockBus.emit.mockClear()
+    sprite.handleInput(250) // < 100ms since last emit — should not emit
+    expect(mockBus.emit).not.toHaveBeenCalled()
+
+    sprite.x = 110
+    sprite.handleInput(350) // >= 100ms since last emit — should emit
+    expect(mockBus.emit).toHaveBeenCalledWith('human-moved', 110, 200)
+  })
+
+  it('não emite human-moved quando posição não muda', () => {
+    const sprite = new HumanSprite(scene as never, 50, 50)
+    sprite.x = 100
+    sprite.y = 200
+
+    sprite.handleInput(200) // first emit
+    mockBus.emit.mockClear()
+
+    sprite.handleInput(400) // > 100ms but same position
+    expect(mockBus.emit).not.toHaveBeenCalled()
+  })
+})

--- a/src/game/objects/HumanSprite.ts
+++ b/src/game/objects/HumanSprite.ts
@@ -1,0 +1,175 @@
+import Phaser from 'phaser'
+import { EventBus } from '../EventBus'
+
+/**
+ * HumanSprite — avatar do jogador com movimento WASD/clique (#94).
+ *
+ * Usa o spritesheet `agent-sprite` com tint diferenciado.
+ * Colide com layers `walls` e `furniture`.
+ * Câmera segue com lerp suave.
+ * Emite posição via EventBus a cada 100ms (debounce).
+ */
+
+type Direction = 'down' | 'left' | 'right' | 'up'
+
+const SPEED = 80
+const EMIT_INTERVAL_MS = 100
+
+export class HumanSprite extends Phaser.Physics.Arcade.Sprite {
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys
+  private wasd!: { W: Phaser.Input.Keyboard.Key; A: Phaser.Input.Keyboard.Key; S: Phaser.Input.Keyboard.Key; D: Phaser.Input.Keyboard.Key }
+  private currentDirection: Direction = 'down'
+  private lastEmitTime = 0
+  private lastEmittedX = 0
+  private lastEmittedY = 0
+  private clickTween: Phaser.Tweens.Tween | null = null
+
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    super(scene, x, y, 'agent-sprite', 0)
+
+    scene.add.existing(this)
+    scene.physics.add.existing(this)
+
+    this.setTint(0x3b82f6) // blue to distinguish from agents
+    this.setDepth(20) // above agent sprites (depth 10)
+    this.setCollideWorldBounds(true)
+
+    const body = this.body as Phaser.Physics.Arcade.Body
+    body.setSize(12, 12)
+    body.setOffset(2, 4)
+
+    if (scene.input.keyboard) {
+      this.cursors = scene.input.keyboard.createCursorKeys()
+      this.wasd = {
+        W: scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.W),
+        A: scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.A),
+        S: scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.S),
+        D: scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.D),
+      }
+    }
+
+    scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      const worldPoint = scene.cameras.main.getWorldPoint(pointer.x, pointer.y)
+      this.moveToPoint(worldPoint.x, worldPoint.y)
+    })
+
+    this.play('idle-down')
+  }
+
+  /** Configura câmera follow e colisão com layers do mapa. */
+  setupCamera(
+    camera: Phaser.Cameras.Scene2D.Camera,
+    wallsLayer: Phaser.Tilemaps.TilemapLayer | null,
+    furnitureLayer: Phaser.Tilemaps.TilemapLayer | null,
+  ): void {
+    camera.startFollow(this, true, 0.1, 0.1)
+
+    if (wallsLayer) this.scene.physics.add.collider(this, wallsLayer)
+    if (furnitureLayer) this.scene.physics.add.collider(this, furnitureLayer)
+  }
+
+  /** Move via clique — tween até o ponto alvo. */
+  private moveToPoint(x: number, y: number): void {
+    this.clickTween?.stop()
+
+    const dx = x - this.x
+    const dy = y - this.y
+    const dist = Math.sqrt(dx * dx + dy * dy)
+
+    if (dist < 4) return
+
+    this.currentDirection = this.directionFrom(dx, dy)
+    this.play(`walk-${this.currentDirection}`, true)
+
+    const body = this.body as Phaser.Physics.Arcade.Body
+    this.scene.physics.moveTo(this, x, y, SPEED)
+
+    const duration = (dist / SPEED) * 1000
+
+    this.clickTween = this.scene.tweens.addCounter({
+      from: 0,
+      to: 1,
+      duration,
+      onComplete: () => {
+        body.setVelocity(0, 0)
+        this.play('idle-down', true)
+        this.clickTween = null
+      },
+    })
+  }
+
+  /** Chamado a cada frame pelo OfficeScene.update(). */
+  handleInput(time: number): void {
+    if (!this.cursors) return
+
+    const body = this.body as Phaser.Physics.Arcade.Body
+    const left = this.cursors.left?.isDown || this.wasd.A.isDown
+    const right = this.cursors.right?.isDown || this.wasd.D.isDown
+    const up = this.cursors.up?.isDown || this.wasd.W.isDown
+    const down = this.cursors.down?.isDown || this.wasd.S.isDown
+
+    const hasInput = left || right || up || down
+
+    if (hasInput) {
+      // Cancel click movement when keyboard takes over
+      if (this.clickTween) {
+        this.clickTween.stop()
+        this.clickTween = null
+      }
+
+      let vx = 0
+      let vy = 0
+      if (left) vx -= SPEED
+      if (right) vx += SPEED
+      if (up) vy -= SPEED
+      if (down) vy += SPEED
+
+      // Normalize diagonal speed
+      if (vx !== 0 && vy !== 0) {
+        const factor = SPEED / Math.sqrt(vx * vx + vy * vy)
+        vx *= factor
+        vy *= factor
+      }
+
+      body.setVelocity(vx, vy)
+
+      const dir = this.directionFrom(vx, vy)
+      if (dir !== this.currentDirection) {
+        this.currentDirection = dir
+        this.play(`walk-${dir}`, true)
+      } else if (!this.anims.isPlaying || this.anims.currentAnim?.key === 'idle-down') {
+        this.play(`walk-${dir}`, true)
+      }
+    } else if (!this.clickTween) {
+      body.setVelocity(0, 0)
+
+      if (this.anims.currentAnim?.key !== 'idle-down') {
+        this.play('idle-down', true)
+      }
+    }
+
+    this.emitPosition(time)
+  }
+
+  /** Emite posição debounced via EventBus. */
+  private emitPosition(time: number): void {
+    if (time - this.lastEmitTime < EMIT_INTERVAL_MS) return
+
+    const x = Math.round(this.x)
+    const y = Math.round(this.y)
+
+    if (x === this.lastEmittedX && y === this.lastEmittedY) return
+
+    this.lastEmitTime = time
+    this.lastEmittedX = x
+    this.lastEmittedY = y
+    EventBus.emit('human-moved', x, y)
+  }
+
+  private directionFrom(dx: number, dy: number): Direction {
+    if (Math.abs(dx) >= Math.abs(dy)) {
+      return dx > 0 ? 'right' : 'left'
+    }
+    return dy > 0 ? 'down' : 'up'
+  }
+}

--- a/src/game/scenes/OfficeScene.ts
+++ b/src/game/scenes/OfficeScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { EventBus } from '../EventBus'
 import { AgentSprite, registerAgentAnimations } from '../objects/AgentSprite'
+import { HumanSprite } from '../objects/HumanSprite'
 import type { AgentOfficeData } from '../../hooks/useOfficeState'
 import { getAgentColor } from '../../constants/agent'
 import { type Option, Some, None, isSome } from '@tecnomancy/alchemy/option'
@@ -30,6 +31,7 @@ export class OfficeScene extends Phaser.Scene {
   private zoneRects = new Map<string, Phaser.Geom.Rectangle>()
   private agentSprites = new Map<string, AgentSprite>()
   private readonly onAgentsUpdated = (agents: AgentOfficeData[]) => this.syncAgents(agents)
+  private humanSprite: HumanSprite | null = null
   wallsLayer: Phaser.Tilemaps.TilemapLayer | null = null
   furnitureLayer: Phaser.Tilemaps.TilemapLayer | null = null
 
@@ -55,12 +57,26 @@ export class OfficeScene extends Phaser.Scene {
     this.setupCamera(map)
     registerAgentAnimations(this)
 
+    // HumanSprite no lobby (centro do mapa)
+    const spawnX = map.widthInPixels / 2
+    const spawnY = map.heightInPixels - 48
+    this.humanSprite = new HumanSprite(this, spawnX, spawnY)
+    this.humanSprite.setupCamera(
+      this.cameras.main,
+      this.wallsLayer,
+      this.furnitureLayer,
+    )
+
     EventBus.on('agents-updated', this.onAgentsUpdated)
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       EventBus.off('agents-updated', this.onAgentsUpdated)
     })
 
     EventBus.emit('scene-ready', this)
+  }
+
+  update(time: number): void {
+    this.humanSprite?.handleInput(time)
   }
 
   /** Sincroniza AgentSprites com a lista de agentes do React. */


### PR DESCRIPTION
## Summary
- Cria `HumanSprite` com movimento WASD + setas + clique no mapa
- Câmera segue o jogador com lerp suave (0.1)
- Colisão com layers `walls` e `furniture`
- Emite posição via EventBus com debounce de 100ms
- Integrado no `OfficeScene` com spawn no lobby

## Test plan
- [x] 9 testes unitários cobrindo criação, input, câmera, debounce e colisão
- [x] 159 testes totais passando
- [x] Typecheck limpo
- [ ] Teste manual: WASD move sprite, clique move sprite, câmera acompanha

Closes #94