### PR TITLE
feat(socket): emitir posição do HumanSprite via socket

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,13 @@ import { getSocket } from './services/socket'
 import { PhaserGame } from './game/PhaserGame'
 import type { PhaserGameRef } from './game/PhaserGame'
 import { usePhaserBridge } from './hooks/usePhaserBridge'
+import { useHumanSocket } from './hooks/useHumanSocket'
 
 export function App() {
   useSocket()
   const { agents, users, isLoading, error, retry } = useOfficeState()
   usePhaserBridge(agents)
+  useHumanSocket()
 
   const overlayRef = useRef<HTMLDivElement>(null)
   const phaserRef = useRef<PhaserGameRef>(null)
@@ -31,7 +33,6 @@ export function App() {
             key={user.socketId}
             user={user}
             isMe={user.socketId === mySocketId}
-            canvasRef={overlayRef}
           />
         ))}
         <OfficeOverlay isLoading={isLoading} error={error} onRetry={retry} />

--- a/src/components/HumanAvatar.test.tsx
+++ b/src/components/HumanAvatar.test.tsx
@@ -1,17 +1,7 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
-import { createRef } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import { HumanAvatar } from './HumanAvatar'
 import type { UserOfficeData } from '../hooks/useOfficeState'
-
-const mockEmit = vi.fn()
-
-vi.mock('../services/socket', () => ({
-  getSocket: () => ({ emit: mockEmit }),
-}))
-
-// Captures the last onDragEnd handler so tests can invoke it directly
-let capturedOnDragEnd: ((_e: unknown, info: unknown) => void) | undefined
 
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
@@ -21,44 +11,18 @@ vi.mock('framer-motion', async () => {
       div: ({
         children,
         style,
-        drag,
-        role,
         'aria-label': ariaLabel,
-        'aria-grabbed': ariaGrabbed,
-        tabIndex,
-        onDragEnd,
-        dragConstraints: _dc,
-        dragElastic: _de,
-        whileDrag: _wd,
         animate: _an,
         transition: _tr,
         ...rest
       }: React.HTMLAttributes<HTMLDivElement> & {
-        drag?: boolean
-        onDragEnd?: (_e: unknown, info: unknown) => void
-        dragConstraints?: unknown
-        dragElastic?: unknown
-        whileDrag?: unknown
         animate?: unknown
         transition?: unknown
-      }) => {
-        if (typeof onDragEnd === 'function') {
-          capturedOnDragEnd = onDragEnd
-        }
-        return (
-          <div
-            style={style}
-            role={role}
-            aria-label={ariaLabel}
-            aria-grabbed={ariaGrabbed}
-            tabIndex={tabIndex}
-            {...(drag !== undefined ? { 'data-drag': String(drag) } : {})}
-            {...rest}
-          >
-            {children}
-          </div>
-        )
-      },
+      }) => (
+        <div style={style} aria-label={ariaLabel} {...rest}>
+          {children}
+        </div>
+      ),
     },
   }
 })
@@ -71,147 +35,45 @@ const mockUser: UserOfficeData = {
   y: 80,
 }
 
-const canvasRef = createRef<HTMLDivElement>()
-
-/** Build a canvas ref with a specific getBoundingClientRect */
-function makeCanvasRef(rect: { left: number; top: number; width: number; height: number }) {
-  const div = document.createElement('div')
-  div.getBoundingClientRect = () => ({
-    left: rect.left,
-    top: rect.top,
-    width: rect.width,
-    height: rect.height,
-    right: rect.left + rect.width,
-    bottom: rect.top + rect.height,
-    x: rect.left,
-    y: rect.top,
-    toJSON: () => {},
-  })
-  return { current: div } as React.RefObject<HTMLDivElement>
-}
-
 describe('HumanAvatar', () => {
-  it('shows user initials', () => {
-    render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+  it('mostra iniciais do usuário', () => {
+    render(<HumanAvatar user={mockUser} isMe={false} />)
     expect(screen.getByText('AL')).toBeTruthy()
   })
 
-  it('shows user name', () => {
-    render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+  it('mostra nome do usuário', () => {
+    render(<HumanAvatar user={mockUser} isMe={false} />)
     expect(screen.getByText('Alice Lima')).toBeTruthy()
   })
 
-  it('shows YOU badge when isMe=true', () => {
-    render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
+  it('mostra badge YOU quando isMe=true', () => {
+    render(<HumanAvatar user={mockUser} isMe={true} />)
     expect(screen.getByText('you')).toBeTruthy()
   })
 
-  it('does not show YOU badge when isMe=false', () => {
-    render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+  it('não mostra badge YOU quando isMe=false', () => {
+    render(<HumanAvatar user={mockUser} isMe={false} />)
     expect(screen.queryByText('you')).toBeNull()
   })
 
-  it('has drag active only when isMe=true', () => {
-    const { container } = render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
-    const el = container.firstChild as HTMLElement
-    expect(el.getAttribute('data-drag')).toBe('true')
-  })
-
-  it('has no drag when isMe=false', () => {
-    const { container } = render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
-    const el = container.firstChild as HTMLElement
-    expect(el.getAttribute('data-drag')).toBeNull()
-  })
-
-  it('has role=button and aria-label when isMe=true', () => {
-    render(<HumanAvatar user={mockUser} isMe={true} canvasRef={canvasRef} />)
-    const btn = screen.getByRole('button')
-    expect(btn).toBeTruthy()
-    expect(btn.getAttribute('aria-label')).toContain('Alice Lima')
-  })
-
-  it('has no role=button when isMe=false', () => {
-    render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
-    expect(screen.queryByRole('button')).toBeNull()
-  })
-
-  it('has aria-label describing the user when isMe=false', () => {
-    const { container } = render(<HumanAvatar user={mockUser} isMe={false} canvasRef={canvasRef} />)
+  it('aria-label contém nome quando isMe=true', () => {
+    const { container } = render(<HumanAvatar user={mockUser} isMe={true} />)
     const el = container.firstChild as HTMLElement
     expect(el.getAttribute('aria-label')).toContain('Alice Lima')
+    expect(el.getAttribute('aria-label')).toContain('your avatar')
   })
 
-  describe('handleDragEnd', () => {
-    afterEach(() => {
-      mockEmit.mockClear()
-      capturedOnDragEnd = undefined
-      vi.useRealTimers()
-    })
+  it('aria-label contém nome quando isMe=false', () => {
+    const { container } = render(<HumanAvatar user={mockUser} isMe={false} />)
+    const el = container.firstChild as HTMLElement
+    expect(el.getAttribute('aria-label')).toContain('Alice Lima')
+    expect(el.getAttribute('aria-label')).toContain('user')
+  })
 
-    it('emits office:user:move with % coords when isMe=true', () => {
-      const ref = makeCanvasRef({ left: 0, top: 0, width: 1000, height: 500 })
-      render(<HumanAvatar user={mockUser} isMe={true} canvasRef={ref} />)
-
-      act(() => {
-        capturedOnDragEnd?.(null, { point: { x: 500, y: 250 } })
-      })
-
-      expect(mockEmit).toHaveBeenCalledWith('office:user:move', { x: 50, y: 50 })
-    })
-
-    it('does not emit when isMe=false', () => {
-      const ref = makeCanvasRef({ left: 0, top: 0, width: 1000, height: 500 })
-      render(<HumanAvatar user={mockUser} isMe={false} canvasRef={ref} />)
-
-      act(() => {
-        capturedOnDragEnd?.(null, { point: { x: 500, y: 250 } })
-      })
-
-      expect(mockEmit).not.toHaveBeenCalled()
-    })
-
-    it('does not emit when canvasRef.current is null', () => {
-      const ref = { current: null } as unknown as React.RefObject<HTMLDivElement>
-      render(<HumanAvatar user={mockUser} isMe={true} canvasRef={ref} />)
-
-      act(() => {
-        capturedOnDragEnd?.(null, { point: { x: 500, y: 250 } })
-      })
-
-      expect(mockEmit).not.toHaveBeenCalled()
-    })
-
-    it('debounces — does not emit a second event within 100ms', () => {
-      vi.useFakeTimers()
-      const ref = makeCanvasRef({ left: 0, top: 0, width: 1000, height: 500 })
-      render(<HumanAvatar user={mockUser} isMe={true} canvasRef={ref} />)
-
-      act(() => {
-        capturedOnDragEnd?.(null, { point: { x: 500, y: 250 } })
-      })
-      act(() => {
-        capturedOnDragEnd?.(null, { point: { x: 600, y: 300 } })
-      })
-
-      expect(mockEmit).toHaveBeenCalledTimes(1)
-    })
-
-    it('emits again after debounce window elapses', () => {
-      vi.useFakeTimers()
-      const ref = makeCanvasRef({ left: 0, top: 0, width: 1000, height: 500 })
-      render(<HumanAvatar user={mockUser} isMe={true} canvasRef={ref} />)
-
-      act(() => {
-        capturedOnDragEnd?.(null, { point: { x: 500, y: 250 } })
-      })
-      act(() => {
-        vi.advanceTimersByTime(101)
-      })
-      act(() => {
-        capturedOnDragEnd?.(null, { point: { x: 600, y: 300 } })
-      })
-
-      expect(mockEmit).toHaveBeenCalledTimes(2)
-    })
+  it('posiciona via left/top em porcentagem', () => {
+    const { container } = render(<HumanAvatar user={mockUser} isMe={false} />)
+    const el = container.firstChild as HTMLElement
+    expect(el.style.left).toBe('50%')
+    expect(el.style.top).toBe('80%')
   })
 })

--- a/src/components/HumanAvatar.tsx
+++ b/src/components/HumanAvatar.tsx
@@ -1,18 +1,13 @@
-import { memo, useRef, useCallback } from 'react'
+import { memo } from 'react'
 import { motion } from 'framer-motion'
-import { getSocket } from '../services/socket'
-import { hashColor, initials, toPercent } from '../utils/avatar'
+import { hashColor, initials } from '../utils/avatar'
 import type { UserOfficeData } from '../hooks/useOfficeState'
 
 interface HumanAvatarProps {
   user: UserOfficeData
-  /** Whether this is the current user's own avatar (draggable) */
+  /** Whether this is the current user's own avatar */
   isMe: boolean
-  /** Ref to the canvas element for calculating drag constraints */
-  canvasRef: React.RefObject<HTMLDivElement | null>
 }
-
-const EMIT_DEBOUNCE_MS = 100
 
 const STYLES = {
   nameStack: {
@@ -41,38 +36,19 @@ const STYLES = {
   } as React.CSSProperties,
 }
 
-export const HumanAvatar = memo(function HumanAvatar({ user, isMe, canvasRef }: HumanAvatarProps) {
+/**
+ * HumanAvatar — exibe avatar de usuários remotos na overlay React (#95).
+ *
+ * Movimento local agora é via HumanSprite no Phaser (#94).
+ * Este componente apenas renderiza a posição recebida via socket.
+ */
+export const HumanAvatar = memo(function HumanAvatar({ user, isMe }: HumanAvatarProps) {
   const color = hashColor(user.userId)
   const label = initials(user.name)
-  const lastEmitAt = useRef(0)
-
-  const handleDragEnd = useCallback(
-    (_: unknown, info: { point: { x: number; y: number } }) => {
-      if (!isMe) return
-
-      const canvas = canvasRef.current
-      if (!canvas) return
-
-      const rect = canvas.getBoundingClientRect()
-      const x = toPercent(info.point.x - rect.left, rect.width)
-      const y = toPercent(info.point.y - rect.top, rect.height)
-
-      // Debounce to avoid event flooding
-      const now = Date.now()
-      if (now - lastEmitAt.current < EMIT_DEBOUNCE_MS) return
-      lastEmitAt.current = now
-
-      getSocket().emit('office:user:move', { x, y })
-    },
-    [isMe, canvasRef]
-  )
 
   return (
     <motion.div
-      role={isMe ? 'button' : undefined}
-      aria-label={isMe ? `your avatar: ${user.name}, drag to move` : `user ${user.name}`}
-      aria-grabbed={isMe ? false : undefined}
-      tabIndex={isMe ? 0 : undefined}
+      aria-label={isMe ? `your avatar: ${user.name}` : `user ${user.name}`}
       style={{
         position: 'absolute',
         left: `${user.x}%`,
@@ -82,18 +58,11 @@ export const HumanAvatar = memo(function HumanAvatar({ user, isMe, canvasRef }: 
         flexDirection: 'column',
         alignItems: 'center',
         gap: 4,
-        cursor: isMe ? 'grab' : 'default',
         userSelect: 'none',
         zIndex: isMe ? 20 : 10,
       }}
-      // Smoothly animate to new position (other users)
       animate={{ left: `${user.x}%`, top: `${user.y}%` }}
       transition={{ type: 'spring', stiffness: 200, damping: 25 }}
-      drag={isMe || undefined}
-      dragConstraints={canvasRef}
-      dragElastic={0.05}
-      whileDrag={{ scale: 1.12, cursor: 'grabbing', zIndex: 1000 }}
-      onDragEnd={handleDragEnd}
     >
       {/* Circular avatar */}
       <div

--- a/src/hooks/useHumanSocket.test.ts
+++ b/src/hooks/useHumanSocket.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { mockBus } = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+  const mockBus = {
+    emit: vi.fn((event: string, ...args: unknown[]) => {
+      listeners.get(event)?.forEach((fn) => fn(...args))
+    }),
+    on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(fn)
+    }),
+    off: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(fn)
+    }),
+  }
+  return { mockBus, listeners }
+})
+
+vi.mock('../game/EventBus', () => ({ EventBus: mockBus }))
+
+const mockSocketEmit = vi.fn()
+vi.mock('../services/socket', () => ({
+  getSocket: () => ({ emit: mockSocketEmit }),
+}))
+
+import { useHumanSocket } from './useHumanSocket'
+
+describe('useHumanSocket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('escuta human-moved no EventBus ao montar', () => {
+    renderHook(() => useHumanSocket())
+    expect(mockBus.on).toHaveBeenCalledWith('human-moved', expect.any(Function))
+  })
+
+  it('emite office:user:move via socket quando EventBus dispara human-moved', () => {
+    renderHook(() => useHumanSocket())
+
+    // Simula EventBus disparando human-moved
+    mockBus.emit('human-moved', 100, 200)
+
+    expect(mockSocketEmit).toHaveBeenCalledWith('office:user:move', { x: 100, y: 200 })
+  })
+
+  it('remove listener do EventBus ao desmontar', () => {
+    const { unmount } = renderHook(() => useHumanSocket())
+    unmount()
+    expect(mockBus.off).toHaveBeenCalledWith('human-moved', expect.any(Function))
+  })
+
+  it('não emite socket sem evento do EventBus', () => {
+    renderHook(() => useHumanSocket())
+    expect(mockSocketEmit).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useHumanSocket.ts
+++ b/src/hooks/useHumanSocket.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+import { EventBus } from '../game/EventBus'
+import { getSocket } from '../services/socket'
+
+/**
+ * useHumanSocket — conecta EventBus `human-moved` ao socket `office:user:move` (#95).
+ *
+ * HumanSprite emite posição via EventBus (já debounced 100ms no Phaser).
+ * Este hook escuta e repassa ao servidor via socket.
+ */
+export function useHumanSocket(): void {
+  useEffect(() => {
+    const onHumanMoved = (x: number, y: number) => {
+      getSocket().emit('office:user:move', { x, y })
+    }
+
+    EventBus.on('human-moved', onHumanMoved)
+
+    return () => {
+      EventBus.off('human-moved', onHumanMoved)
+    }
+  }, [])
+}


### PR DESCRIPTION
## Summary
- Cria hook `useHumanSocket` que conecta EventBus `human-moved` → socket `office:user:move`
- Remove lógica de drag CSS do `HumanAvatar` (substituída pelo Phaser #94)
- HumanAvatar agora é display-only para usuários remotos

## Test plan
- [x] 4 testes para useHumanSocket (listener, emit, cleanup, idle)
- [x] 7 testes para HumanAvatar simplificado (sem drag)
- [x] 156 testes totais passando
- [x] Typecheck limpo
- [ ] Teste manual: mover sprite → posição emitida via socket

Closes #95