### PR TITLE
feat(ui): SpeechBubble posicionado sobre sprite Phaser

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,24 @@
 import { useRef } from 'react'
+import { isSome } from '@tecnomancy/alchemy'
 import { useSocket } from './hooks/useSocket'
 import { useOfficeState } from './hooks/useOfficeState'
 import { OfficeOverlay } from './components/OfficeOverlay'
 import { HumanAvatar } from './components/HumanAvatar'
+import { SpeechBubble } from './components/SpeechBubble'
 import { OnlineUsersList } from './components/OnlineUsersList'
 import { getSocket } from './services/socket'
 import { PhaserGame } from './game/PhaserGame'
 import type { PhaserGameRef } from './game/PhaserGame'
 import { usePhaserBridge } from './hooks/usePhaserBridge'
 import { useHumanSocket } from './hooks/useHumanSocket'
+import { useSpritePositions } from './hooks/useSpritePositions'
 
 export function App() {
   useSocket()
   const { agents, users, isLoading, error, retry } = useOfficeState()
   usePhaserBridge(agents)
   useHumanSocket()
+  const spritePositions = useSpritePositions()
 
   const overlayRef = useRef<HTMLDivElement>(null)
   const phaserRef = useRef<PhaserGameRef>(null)
@@ -26,7 +30,7 @@ export function App() {
       {/* Phaser canvas — camada base */}
       <PhaserGame ref={phaserRef} />
 
-      {/* React overlay — human avatars e feedback de carregamento */}
+      {/* React overlay — human avatars, speech bubbles e feedback */}
       <div ref={overlayRef} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
         {users.map((user) => (
           <HumanAvatar
@@ -35,6 +39,24 @@ export function App() {
             isMe={user.socketId === mySocketId}
           />
         ))}
+
+        {/* SpeechBubbles posicionados sobre sprites Phaser (#96) */}
+        {agents
+          .filter((a) => isSome(a.speechText))
+          .map((agent) => {
+            const pos = spritePositions.get(agent.id)
+            if (!pos) return null
+            return (
+              <SpeechBubble
+                key={`speech-${agent.id}`}
+                text={agent.speechText}
+                color={agent.color}
+                screenX={pos.x}
+                screenY={pos.y}
+              />
+            )
+          })}
+
         <OfficeOverlay isLoading={isLoading} error={error} onRetry={retry} />
       </div>
 

--- a/src/components/SpeechBubble.tsx
+++ b/src/components/SpeechBubble.tsx
@@ -5,16 +5,15 @@ import { type Option, isSome } from '@tecnomancy/alchemy'
 interface SpeechBubbleProps {
   text: Option<string>
   color: string
+  /** Screen position (pixels) — when set, renders at fixed position */
+  screenX?: number
+  screenY?: number
 }
 
 const MAX_LENGTH = 40
 
 const STYLES = {
   bubble: {
-    position: 'absolute',
-    bottom: 'calc(100% + 8px)',
-    left: '50%',
-    transform: 'translateX(-50%)',
     maxWidth: 180,
     padding: '5px 8px',
     background: 'rgba(15, 23, 42, 0.92)',
@@ -53,12 +52,36 @@ const variants = {
   exit: { scale: 0, opacity: 0, transition: { duration: 0.2 } },
 }
 
-export const SpeechBubble = memo(function SpeechBubble({ text, color }: SpeechBubbleProps) {
+/** Offset above the sprite (pixels) */
+const BUBBLE_OFFSET_Y = 28
+
+export const SpeechBubble = memo(function SpeechBubble({
+  text,
+  color,
+  screenX,
+  screenY,
+}: SpeechBubbleProps) {
   const content = isSome(text)
     ? text.value.length > MAX_LENGTH
       ? `${text.value.slice(0, MAX_LENGTH)}…`
       : text.value
     : null
+
+  const isPositioned = screenX !== undefined && screenY !== undefined
+
+  const positionStyle: React.CSSProperties = isPositioned
+    ? {
+        position: 'fixed',
+        left: screenX,
+        top: screenY - BUBBLE_OFFSET_Y,
+        transform: 'translate(-50%, -100%)',
+      }
+    : {
+        position: 'absolute',
+        bottom: 'calc(100% + 8px)',
+        left: '50%',
+        transform: 'translateX(-50%)',
+      }
 
   return (
     <AnimatePresence>
@@ -69,7 +92,7 @@ export const SpeechBubble = memo(function SpeechBubble({ text, color }: SpeechBu
           initial="hidden"
           animate="visible"
           exit="exit"
-          style={{ ...STYLES.bubble, border: `1px solid ${color}80` }}
+          style={{ ...STYLES.bubble, ...positionStyle, border: `1px solid ${color}80` }}
         >
           {content}
           {/* Downward-pointing arrow */}

--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -12,11 +12,17 @@ import type { AgentOfficeData } from '../hooks/useOfficeState'
  *   agent-speech-position — posição em tela do balão de fala
  *   human-moved      — posição do HumanSprite (para emitir via socket)
  */
+export interface SpriteScreenPos {
+  x: number
+  y: number
+}
+
 export interface OfficeEventMap {
   'scene-ready': [scene: Phaser.Scene]
   'agents-updated': [agents: AgentOfficeData[]]
   'agent-speech': [agentId: string, text: string]
   'agent-speech-position': [agentId: string, x: number, y: number]
+  'sprite-positions': [positions: Map<string, SpriteScreenPos>]
   'human-moved': [x: number, y: number]
 }
 

--- a/src/game/scenes/OfficeScene.ts
+++ b/src/game/scenes/OfficeScene.ts
@@ -1,5 +1,5 @@
 import Phaser from 'phaser'
-import { EventBus } from '../EventBus'
+import { EventBus, type SpriteScreenPos } from '../EventBus'
 import { AgentSprite, registerAgentAnimations } from '../objects/AgentSprite'
 import { HumanSprite } from '../objects/HumanSprite'
 import type { AgentOfficeData } from '../../hooks/useOfficeState'
@@ -77,6 +77,23 @@ export class OfficeScene extends Phaser.Scene {
 
   update(time: number): void {
     this.humanSprite?.handleInput(time)
+    this.emitSpritePositions()
+  }
+
+  /** Converte posições de sprites do mundo para coordenadas de tela e emite via EventBus. */
+  private emitSpritePositions(): void {
+    if (this.agentSprites.size === 0) return
+
+    const cam = this.cameras.main
+    const positions = new Map<string, SpriteScreenPos>()
+
+    for (const [id, sprite] of this.agentSprites) {
+      const sx = (sprite.x - cam.worldView.x) * cam.zoom + cam.x
+      const sy = (sprite.y - cam.worldView.y) * cam.zoom + cam.y
+      positions.set(id, { x: Math.round(sx), y: Math.round(sy) })
+    }
+
+    EventBus.emit('sprite-positions', positions)
   }
 
   /** Sincroniza AgentSprites com a lista de agentes do React. */

--- a/src/hooks/useSpritePositions.test.ts
+++ b/src/hooks/useSpritePositions.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+const { mockBus } = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+  const mockBus = {
+    emit: vi.fn((event: string, ...args: unknown[]) => {
+      listeners.get(event)?.forEach((fn) => fn(...args))
+    }),
+    on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(fn)
+    }),
+    off: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(fn)
+    }),
+  }
+  return { mockBus, listeners }
+})
+
+vi.mock('../game/EventBus', () => ({ EventBus: mockBus }))
+
+import { useSpritePositions } from './useSpritePositions'
+
+describe('useSpritePositions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retorna Map vazio inicialmente', () => {
+    const { result } = renderHook(() => useSpritePositions())
+    expect(result.current.size).toBe(0)
+  })
+
+  it('escuta sprite-positions no EventBus', () => {
+    renderHook(() => useSpritePositions())
+    expect(mockBus.on).toHaveBeenCalledWith('sprite-positions', expect.any(Function))
+  })
+
+  it('atualiza posições quando EventBus emite', () => {
+    const { result } = renderHook(() => useSpritePositions())
+
+    const positions = new Map([
+      ['agent-1', { x: 100, y: 200 }],
+      ['agent-2', { x: 300, y: 400 }],
+    ])
+
+    act(() => {
+      mockBus.emit('sprite-positions', positions)
+    })
+
+    expect(result.current.get('agent-1')).toEqual({ x: 100, y: 200 })
+    expect(result.current.get('agent-2')).toEqual({ x: 300, y: 400 })
+  })
+
+  it('remove listener ao desmontar', () => {
+    const { unmount } = renderHook(() => useSpritePositions())
+    unmount()
+    expect(mockBus.off).toHaveBeenCalledWith('sprite-positions', expect.any(Function))
+  })
+})

--- a/src/hooks/useSpritePositions.ts
+++ b/src/hooks/useSpritePositions.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { EventBus, type SpriteScreenPos } from '../game/EventBus'
+
+/**
+ * useSpritePositions — retorna coordenadas de tela dos AgentSprites (#96).
+ *
+ * Escuta `sprite-positions` do EventBus (emitido pelo OfficeScene a cada frame)
+ * e retorna um Map<agentId, {x, y}> com posições em pixels na viewport.
+ */
+export function useSpritePositions(): Map<string, SpriteScreenPos> {
+  const [positions, setPositions] = useState<Map<string, SpriteScreenPos>>(() => new Map())
+
+  useEffect(() => {
+    const onPositions = (pos: Map<string, SpriteScreenPos>) => {
+      setPositions(pos)
+    }
+
+    EventBus.on('sprite-positions', onPositions)
+
+    return () => {
+      EventBus.off('sprite-positions', onPositions)
+    }
+  }, [])
+
+  return positions
+}


### PR DESCRIPTION
## Summary
- OfficeScene emite `sprite-positions` com coords de tela dos AgentSprites a cada frame
- Novo hook `useSpritePositions` coleta posições via EventBus
- SpeechBubble aceita `screenX/screenY` para posição fixa sobre sprite
- App.tsx renderiza SpeechBubbles filtrados por `isSome(speechText)` nas coords do sprite

## Test plan
- [x] 4 testes para useSpritePositions (init, listener, update, cleanup)
- [x] 160 testes totais passando
- [x] Typecheck limpo
- [ ] Teste manual: balão aparece sobre sprite correto em qualquer zoom

Closes #96