### PR TITLE
feat(dx): validar VITE_MAGO_BACKEND_URL no startup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,10 @@ import { createRoot } from 'react-dom/client'
 import { App } from './App'
 import { ErrorBoundary } from './components/ErrorBoundary'
 
+if (import.meta.env.DEV && !import.meta.env.VITE_MAGO_BACKEND_URL) {
+  console.warn('[mago-office] VITE_MAGO_BACKEND_URL não definido — usando http://localhost:3002')
+}
+
 const root = document.getElementById('root')
 if (!root) throw new Error('Root element not found')
 


### PR DESCRIPTION
## Summary
- Adiciona warning no console em dev quando `VITE_MAGO_BACKEND_URL` não está definido
- `.env.example` já existia com a variável documentada

## Test plan
- [x] 160 testes passando
- [x] Typecheck limpo

Closes #83